### PR TITLE
[박재홍] 2회차 미션 Level4, Level5 제출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+### production profile ###
+src/main/resources/application-prod.yml

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 group = 'com.jaehong'
-version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.11'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.jaehong'
@@ -11,7 +12,9 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
+
 
 repositories {
     mavenCentral()
@@ -20,12 +23,41 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.7.RELEASE'
+
     compileOnly 'org.projectlombok:lombok'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
+
     annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.7.RELEASE'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+bootJar {
+    dependsOn asciidoctor
+
+    copy {
+        from asciidoctor.outputDir
+        into "src/main/resources/static/docs"
+    }
 }

--- a/src/docs/asciidoc/docinfo.html
+++ b/src/docs/asciidoc/docinfo.html
@@ -1,0 +1,36 @@
+<script>
+    function ready(callbackFunc) {
+        if (document.readyState !== 'loading') {
+            // Document is already ready, call the callback directly
+            callbackFunc();
+        } else if (document.addEventListener) {
+            // All modern browsers to register DOMContentLoaded
+            document.addEventListener('DOMContentLoaded', callbackFunc);
+        } else {
+            // Old IE browsers
+            document.attachEvent('onreadystatechange', function () {
+                if (document.readyState === 'complete') {
+                    callbackFunc();
+                }
+            });
+        }
+    }
+
+    function openPopup(event) {
+
+        const target = event.target;
+        if (target.className !== "popup") {
+            return;
+        }
+
+        event.preventDefault();
+        const screenX = event.screenX;
+        const screenY = event.screenY;
+        window.open(target.href, target.text, `left=${screenX}, top=${screenY}, width=500, height=600, status=no, menubar=no, toolbar=no, resizable=no`);
+    }
+
+    ready(function () {
+        const el = document.getElementById("content");
+        el.addEventListener("click", event => openPopup(event), false);
+    });
+</script>

--- a/src/docs/asciidoc/docinfo.html
+++ b/src/docs/asciidoc/docinfo.html
@@ -34,3 +34,9 @@
         el.addEventListener("click", event => openPopup(event), false);
     });
 </script>
+
+<style>
+    h3 {
+        margin-top: 80px;
+    }
+</style>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -12,8 +12,6 @@ endif::[]
 
 == 게시글 작성 성공
 
-게시글을 생성하는 api 입니다.
-
 === 요청
 
 include::{snippets}/post-create-success/request-body.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,152 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+= API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:docinfo: shared-head
+
+== 게시글 작성 성공
+
+게시글을 생성하는 api 입니다.
+
+=== 요청
+
+include::{snippets}/post-create-success/request-body.adoc[]
+
+=== 요청 필드
+
+include::{snippets}/post-create-success/request-fields.adoc[]
+
+=== 응답
+
+include::{snippets}/post-create-success/http-response.adoc[]
+
+=== 응답 필드
+
+include::{snippets}/post-create-success/response-fields.adoc[]
+
+=== curl
+
+include::{snippets}/post-create-success/curl-request.adoc[]
+
+= 게시글 작성 실패
+
+== 요청
+
+include::{snippets}/post-create-fail/request-body.adoc[]
+
+== 응답
+
+include::{snippets}/post-create-fail/http-response.adoc[]
+
+== curl
+
+include::{snippets}/post-create-fail/curl-request.adoc[]
+
+= 게시글 수정
+게시글을 수정하는 api입니다.
+
+== 요청
+
+include::{snippets}/post-edit/request-body.adoc[]
+
+== 요청 파라미터
+
+include::{snippets}/post-edit/path-parameters.adoc[]
+
+== 요청 필드
+
+include::{snippets}/post-edit/request-fields.adoc[]
+
+== 응답
+
+include::{snippets}/post-edit/http-response.adoc[]
+
+== 응답 필드
+
+include::{snippets}/post-edit/response-fields.adoc[]
+
+== curl
+
+include::{snippets}/post-edit/curl-request.adoc[]
+
+= 게시글 삭제
+
+== 요청 파라미터
+
+include::{snippets}/post-delete/path-parameters.adoc[]
+
+== 응답
+
+include::{snippets}/post-delete/http-response.adoc[]
+
+== curl
+
+include::{snippets}/post-delete/curl-request.adoc[]
+
+= 게시글 단건 조회
+
+== 요청
+
+include::{snippets}/post-inquiry/http-request.adoc[]
+
+== 요청 파라미터
+
+include::{snippets}/post-inquiry/path-parameters.adoc[]
+
+== 응답
+
+include::{snippets}/post-inquiry/http-response.adoc[]
+
+== 응답 필드
+
+include::{snippets}/post-inquiry/response-fields.adoc[]
+
+== curl
+
+include::{snippets}/post-inquiry/curl-request.adoc[]
+
+= 게시글 다건 조회 (키워드 x)
+
+== 요청
+
+include::{snippets}/post-search-all/http-response.adoc[]
+
+== 응답
+
+include::{snippets}/post-search-all/http-response.adoc[]
+
+== 응답 필드
+
+include::{snippets}/post-search-all/response-fields.adoc[]
+
+== curl
+
+include::{snippets}/post-search-all/curl-request.adoc[]
+
+= 게시글 다건 조회 (키워드 O)
+
+== 요청
+
+include::{snippets}/post-search-keyword/http-request.adoc[]
+
+== 요청 쿼리 스트링
+
+include::{snippets}/post-search-keyword/request-parameters.adoc[]
+
+== 응답
+
+include::{snippets}/post-search-keyword/http-response.adoc[]
+
+== 응답 필드
+
+include::{snippets}/post-search-keyword/response-fields.adoc[]
+
+== curl
+
+include::{snippets}/post-search-keyword/curl-request.adoc[]

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/config/WebCorsConfiguration.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/config/WebCorsConfiguration.java
@@ -1,0 +1,34 @@
+package com.jaehong.projectclassjaehongdev.global.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration(proxyBeanMethods = false)
+public class WebCorsConfiguration {
+
+    private final String url;
+
+    public WebCorsConfiguration(@Value("${target.url}") String url) {
+        this.url = url;
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        var source = new UrlBasedCorsConfigurationSource();
+        var config = new CorsConfiguration();
+
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin(this.url);
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.setMaxAge(3600L);
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/controller/DomainControllerAdvice.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/controller/DomainControllerAdvice.java
@@ -20,6 +20,16 @@ public class DomainControllerAdvice {
                 );
     }
 
+    @ExceptionHandler({RuntimeException.class})
+    public ResponseEntity<ErrorResponse> throwRuntimeException(RuntimeException exception) {
+        return ResponseEntity.internalServerError()
+                .body(ErrorResponse.builder()
+                        .code(1)
+                        .message("서버에서 알 수 없는 에러가 발생했습니다.")
+                        .build());
+
+    }
+
     @Getter
     static class ErrorResponse {
         int code;

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
@@ -21,7 +21,7 @@ public enum DomainExceptionCode {
     private final String message;
 
 
-    public DomainException generateError() {
+    public DomainException create() {
         return new DomainException(code, this.generateErrorMessage());
     }
 
@@ -29,7 +29,7 @@ public enum DomainExceptionCode {
         return String.format(BASIC_ERROR_FORMAT, this.code, this.message);
     }
 
-    public DomainException generateError(Object... args) {
+    public DomainException create(Object... args) {
         return new DomainException(code, this.generateErrorMessage(args));
     }
 

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
@@ -13,7 +13,8 @@ public enum DomainExceptionCode {
     POST_SHOULD_NOT_CONTENT_EMPTY(POST.code + 2, "게시글 내용은 필수적으로 필요합니다."),
     POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE(POST.code + 3, "게시글 제목은 %d보다 길게 작성할 수 없습니다 (size: %d)"),
     POST_CONTENT_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE(POST.code + 4, "게시글 내용은 %d보다 길게 작성할 수 없습니다 (size: %d)"),
-    POST_DID_NOT_EXISTS(POST.code + 5, "존재하지 않는 게시글 id 입니다 [id: %d]");
+    POST_DID_NOT_EXISTS(POST.code + 5, "존재하지 않는 게시글 id 입니다 [id: %d]"),
+    POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK(POST.code + 6, "게시글 키워드는 공백을 제외한 1글자 이상이여야 한다 (input: %s)");
 
     private static final String BASIC_ERROR_FORMAT = "[ERROR] [CODE:%d] [Message: %s]";
     private final Integer code;

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/controller/PostController.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/controller/PostController.java
@@ -13,6 +13,7 @@ import com.jaehong.projectclassjaehongdev.post.service.PostEditService;
 import com.jaehong.projectclassjaehongdev.post.service.PostFindService;
 import com.jaehong.projectclassjaehongdev.post.service.PostsFindService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,7 +38,7 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<PostCreateResponse> createNewPost(@RequestBody PostCreateRequest postCreateRequest) {
-        return ResponseEntity.status(201).body(postCreateService.execute(postCreateRequest));
+        return ResponseEntity.status(HttpStatus.CREATED).body(postCreateService.execute(postCreateRequest));
     }
 
     @PatchMapping("/{postId}")
@@ -48,7 +49,7 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
         postDeleteService.execute(postId);
-        return ResponseEntity.status(204).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/domain/Post.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/domain/Post.java
@@ -47,11 +47,11 @@ public class Post {
     }
 
     // 고민 정적 팩토리 메소드로 객체를 생성할때 정해진 규칙을 사용하는 것과 명확한 의미 전달중 어느 것을 선택해야 할까?
-    public static Post createNewPost(String title, String content) {
+    public static Post create(String title, String content) {
         return new Post(title, content);
     }
 
-    public Post updatePost(String editTitle, String editContent) {
+    public Post update(String editTitle, String editContent) {
         return new Post(this.id, editTitle, editContent, createdAt);
     }
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/domain/policy/PostValidationPolicy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/domain/policy/PostValidationPolicy.java
@@ -17,11 +17,11 @@ public class PostValidationPolicy {
      */
     private static void validatePostContent(String content) {
         if (content == null || content.isEmpty() || content.isBlank()) {
-            throw DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.generateError();
+            throw DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.create();
         }
         var contentLength = content.length();
         if (MAX_CONTENT_SIZE < contentLength) {
-            throw DomainExceptionCode.POST_CONTENT_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(MAX_CONTENT_SIZE, contentLength);
+            throw DomainExceptionCode.POST_CONTENT_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.create(MAX_CONTENT_SIZE, contentLength);
         }
 
     }
@@ -31,12 +31,12 @@ public class PostValidationPolicy {
      */
     private static void validatePostTitle(String title) {
         if (title == null || title.isEmpty() || title.isBlank()) {
-            throw DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.generateError();
+            throw DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.create();
         }
         var titleLength = title.length();
 
         if (MAX_TITLE_SIZE < titleLength) {
-            throw DomainExceptionCode.POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(MAX_TITLE_SIZE, titleLength);
+            throw DomainExceptionCode.POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.create(MAX_TITLE_SIZE, titleLength);
         }
     }
 

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/domain/policy/PostValidationPolicy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/domain/policy/PostValidationPolicy.java
@@ -4,7 +4,7 @@ import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
 import com.jaehong.projectclassjaehongdev.post.domain.Post;
 
 public class PostValidationPolicy {
-    private static final Integer MAX_TITLE_SIZE = 100;
+    private static final Integer MAX_TITLE_SIZE = 10;
     private static final Integer MAX_CONTENT_SIZE = 1000;
 
     public static void validateAll(Post post) {
@@ -27,7 +27,7 @@ public class PostValidationPolicy {
     }
 
     /**
-     * @param title null x should not over than 100 words 공백 불가능 띄어쓰기 포함
+     * @param title null x should not over than 10 words 공백 불가능 띄어쓰기 포함
      */
     private static void validatePostTitle(String title) {
         if (title == null || title.isEmpty() || title.isBlank()) {

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/payload/request/PostSearch.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/payload/request/PostSearch.java
@@ -17,6 +17,4 @@ public class PostSearch {
     public PostSearch(String title) {
         this.title = title;
     }
-
-
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/payload/request/PostSearch.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/payload/request/PostSearch.java
@@ -18,8 +18,5 @@ public class PostSearch {
         this.title = title;
     }
 
-    public String getTitle() {
-        return title == null ? "" : title;
-    }
 
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryCustom.java
@@ -1,9 +1,10 @@
 package com.jaehong.projectclassjaehongdev.post.repository;
 
 import com.jaehong.projectclassjaehongdev.post.domain.Post;
-import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
 import java.util.List;
 
 public interface PostRepositoryCustom {
-    List<Post> findBy(PostSearch pageable);
+
+    List<Post> findBy(PostSearchCondition searchCondition);
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.jaehong.projectclassjaehongdev.post.repository;
 
 import com.jaehong.projectclassjaehongdev.post.domain.Post;
-import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
 import java.util.List;
 import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -13,11 +13,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     private final EntityManager entityManager;
 
     @Override
-    public List<Post> findBy(PostSearch postSearch) {
+    public List<Post> findBy(PostSearchCondition postSearchCondition) {
         return entityManager.createQuery("select p from Post p where p.title like :searchTitle order by p.createdAt DESC", Post.class)
-                .setParameter("searchTitle", "%" + postSearch.getTitle() + "%")
+                .setParameter("searchTitle", "%" + postSearchCondition.getKeyword() + "%")
                 .setFirstResult(0)
-                .setMaxResults(postSearch.getLimit())
+                .setMaxResults(postSearchCondition.getLimit())
                 .getResultList();
     }
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostCreateServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostCreateServiceImpl.java
@@ -16,7 +16,7 @@ public class PostCreateServiceImpl implements PostCreateService {
     @Transactional
     @Override
     public PostCreateResponse execute(PostCreateRequest request) {
-        var newPost = Post.createNewPost(request.getTitle(), request.getContent());
+        var newPost = Post.create(request.getTitle(), request.getContent());
         var postEntity = postRepository.save(newPost);
 
         return PostCreateResponse.builder()

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostDeleteServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostDeleteServiceImpl.java
@@ -15,7 +15,7 @@ public class PostDeleteServiceImpl implements PostDeleteService {
     @Override
     public void execute(Long postId) {
         var post = postRepository.findById(postId)
-                .orElseThrow(() -> DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(postId));
+                .orElseThrow(() -> DomainExceptionCode.POST_DID_NOT_EXISTS.create(postId));
         postRepository.delete(post);
     }
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostEditServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostEditServiceImpl.java
@@ -19,7 +19,7 @@ public class PostEditServiceImpl implements PostEditService {
         var previousPost = postRepository.findById(postId)
                 .orElseThrow(() -> DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(postId));
 
-        var updatedPost = postRepository.save(previousPost.updatePost(editRequest.getTitle(), editRequest.getContent()));
+        var updatedPost = postRepository.save(previousPost.update(editRequest.getTitle(), editRequest.getContent()));
 
         return PostEditResponse.builder()
                 .id(updatedPost.getId())

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostEditServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostEditServiceImpl.java
@@ -17,7 +17,7 @@ public class PostEditServiceImpl implements PostEditService {
     @Override
     public PostEditResponse execute(Long postId, PostEditRequest editRequest) {
         var previousPost = postRepository.findById(postId)
-                .orElseThrow(() -> DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(postId));
+                .orElseThrow(() -> DomainExceptionCode.POST_DID_NOT_EXISTS.create(postId));
 
         var updatedPost = postRepository.save(previousPost.update(editRequest.getTitle(), editRequest.getContent()));
 

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostFindServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostFindServiceImpl.java
@@ -18,7 +18,7 @@ public class PostFindServiceImpl implements PostFindService {
     public PostFindResponse execute(Long postId) {
         // 조회 결과
         var postViewed = postRepository.findById(postId)
-                .orElseThrow(() -> DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(postId));
+                .orElseThrow(() -> DomainExceptionCode.POST_DID_NOT_EXISTS.create(postId));
 
         return PostFindResponse.builder().id(postViewed.getId())
                 .title(postViewed.getTitle())

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
@@ -1,53 +1,33 @@
 package com.jaehong.projectclassjaehongdev.post.service;
 
-import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
-import com.jaehong.projectclassjaehongdev.post.domain.Post;
 import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
-import com.jaehong.projectclassjaehongdev.post.payload.response.PostFindResponse;
 import com.jaehong.projectclassjaehongdev.post.payload.response.PostsResponse;
-import com.jaehong.projectclassjaehongdev.post.repository.PostRepository;
-import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
+import com.jaehong.projectclassjaehongdev.post.service.strategy.PostSearchStrategy;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
-@RequiredArgsConstructor
 public class PostsFindServiceImpl implements PostsFindService {
-    private final PostRepository postRepository;
+    private final PostSearchStrategy postFindAllStrategy;
+    private final PostSearchStrategy postFindKeywordStrategy;
 
+    public PostsFindServiceImpl(
+            @Qualifier("PostFindAllStrategy") PostSearchStrategy postFindAllStrategy,
+            @Qualifier("PostFindKeywordStrategy") PostSearchStrategy postFindKeywordStrategy) {
+
+        this.postFindAllStrategy = postFindAllStrategy;
+        this.postFindKeywordStrategy = postFindKeywordStrategy;
+    }
 
     @Transactional(readOnly = true)
     @Override
     public PostsResponse execute(PostSearch postSearch) {
         if (Objects.nonNull(postSearch.getTitle())) {
-            if (postSearch.getTitle().isBlank()) {
-                throw DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(postSearch.getTitle());
-            }
-            return this.findBy(PostSearchCondition.create(postSearch.getTitle()));
+            return this.postFindKeywordStrategy.findBy(postSearch);
         }
-        return this.findBy(PostSearchCondition.createEmptyCondition());
+        return this.postFindAllStrategy.findBy(postSearch);
     }
-
-    private PostsResponse findBy(PostSearchCondition postSearchCondition) {
-        return PostsResponse.from(this.postRepository.findBy(postSearchCondition).stream()
-                .map(this::convertEntityToResponse)
-                .collect(Collectors.toList()));
-    }
-
-    private PostFindResponse convertEntityToResponse(Post post) {
-        return PostFindResponse.builder()
-                .id(post.getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .createdAt(post.getCreatedAt())
-                .build();
-    }
-
-    // 전략을 사용하는 방법
-    // postSearch 를 바탕으로 검색 로직을 수행하는 인터페이스를 수행하는 방법으로 가야할듯
-    // vo 형태로 
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
@@ -1,10 +1,13 @@
 package com.jaehong.projectclassjaehongdev.post.service;
 
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
 import com.jaehong.projectclassjaehongdev.post.domain.Post;
 import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
 import com.jaehong.projectclassjaehongdev.post.payload.response.PostFindResponse;
 import com.jaehong.projectclassjaehongdev.post.payload.response.PostsResponse;
 import com.jaehong.projectclassjaehongdev.post.repository.PostRepository;
+import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +23,18 @@ public class PostsFindServiceImpl implements PostsFindService {
     @Transactional(readOnly = true)
     @Override
     public PostsResponse execute(PostSearch postSearch) {
-        return PostsResponse.from(postRepository.findBy(postSearch)
-                .stream().map(this::convertEntityToResponse)
+        if (Objects.nonNull(postSearch.getTitle())) {
+            if (postSearch.getTitle().isBlank()) {
+                throw DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(postSearch.getTitle());
+            }
+            return this.findBy(PostSearchCondition.create(postSearch.getTitle()));
+        }
+        return this.findBy(PostSearchCondition.createEmptyCondition());
+    }
+
+    private PostsResponse findBy(PostSearchCondition postSearchCondition) {
+        return PostsResponse.from(this.postRepository.findBy(postSearchCondition).stream()
+                .map(this::convertEntityToResponse)
                 .collect(Collectors.toList()));
     }
 
@@ -33,4 +46,8 @@ public class PostsFindServiceImpl implements PostsFindService {
                 .createdAt(post.getCreatedAt())
                 .build();
     }
+
+    // 전략을 사용하는 방법
+    // postSearch 를 바탕으로 검색 로직을 수행하는 인터페이스를 수행하는 방법으로 가야할듯
+    // vo 형태로 
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindAllStrategy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindAllStrategy.java
@@ -1,0 +1,22 @@
+package com.jaehong.projectclassjaehongdev.post.service.strategy;
+
+import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.post.payload.response.PostsResponse;
+import com.jaehong.projectclassjaehongdev.post.repository.PostRepository;
+import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component("PostFindAllStrategy")
+public class PostFindAllStrategy extends PostSearchStrategy {
+    private final PostRepository postRepository;
+
+    @Override
+    public PostsResponse findBy(PostSearch postSearch) {
+        return PostsResponse.from(postRepository.findBy(PostSearchCondition.createEmptyCondition())
+                .stream().map(this::convertEntityToResponse)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategy.java
@@ -7,6 +7,7 @@ import com.jaehong.projectclassjaehongdev.post.repository.PostRepository;
 import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.stereotype.Component;
 
 @Component("PostFindKeywordStrategy")
@@ -16,7 +17,7 @@ public class PostFindKeywordStrategy extends PostSearchStrategy {
 
     @Override
     public PostsResponse findBy(PostSearch postSearch) {
-        if (postSearch.getTitle().isBlank()) {
+        if (Strings.isBlank(postSearch.getTitle())) {
             throw DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(postSearch.getTitle());
         }
         return PostsResponse.from(postRepository.findBy(PostSearchCondition.create(postSearch.getTitle()))

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategy.java
@@ -18,7 +18,7 @@ public class PostFindKeywordStrategy extends PostSearchStrategy {
     @Override
     public PostsResponse findBy(PostSearch postSearch) {
         if (Strings.isBlank(postSearch.getTitle())) {
-            throw DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(postSearch.getTitle());
+            throw DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.create(postSearch.getTitle());
         }
         return PostsResponse.from(postRepository.findBy(PostSearchCondition.create(postSearch.getTitle()))
                 .stream().map(this::convertEntityToResponse)

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategy.java
@@ -1,0 +1,26 @@
+package com.jaehong.projectclassjaehongdev.post.service.strategy;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.post.payload.response.PostsResponse;
+import com.jaehong.projectclassjaehongdev.post.repository.PostRepository;
+import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("PostFindKeywordStrategy")
+@RequiredArgsConstructor
+public class PostFindKeywordStrategy extends PostSearchStrategy {
+    private final PostRepository postRepository;
+
+    @Override
+    public PostsResponse findBy(PostSearch postSearch) {
+        if (postSearch.getTitle().isBlank()) {
+            throw DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(postSearch.getTitle());
+        }
+        return PostsResponse.from(postRepository.findBy(PostSearchCondition.create(postSearch.getTitle()))
+                .stream().map(this::convertEntityToResponse)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostSearchStrategy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostSearchStrategy.java
@@ -1,0 +1,19 @@
+package com.jaehong.projectclassjaehongdev.post.service.strategy;
+
+import com.jaehong.projectclassjaehongdev.post.domain.Post;
+import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.post.payload.response.PostFindResponse;
+import com.jaehong.projectclassjaehongdev.post.payload.response.PostsResponse;
+
+public abstract class PostSearchStrategy {
+    abstract public PostsResponse findBy(PostSearch postSearch);
+
+    protected PostFindResponse convertEntityToResponse(Post post) {
+        return PostFindResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/vo/PostSearchCondition.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/vo/PostSearchCondition.java
@@ -1,0 +1,24 @@
+package com.jaehong.projectclassjaehongdev.post.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostSearchCondition {
+    private final int limit;
+    private final String keyword;
+
+    private PostSearchCondition(String keyword) {
+        this.limit = 100;
+        this.keyword = keyword;
+    }
+
+    public static PostSearchCondition create(String title) {
+        return new PostSearchCondition(title);
+    }
+
+    public static PostSearchCondition createEmptyCondition() {
+        return new PostSearchCondition("");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,9 @@ logging:
         type:
           descriptor:
             sql: trace
+
+
+
+###
+target:
+  url: http://localhost:8080

--- a/src/test/java/com/jaehong/projectclassjaehongdev/globa/domain/DomainExceptionCodeTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/globa/domain/DomainExceptionCodeTest.java
@@ -16,7 +16,7 @@ class DomainExceptionCodeTest {
 
     @Test
     void 정상적으로_도메인_에러가_생성됩니다() {
-        var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.generateError();
+        var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.create();
         assertThatThrownBy(() -> {
             throw domainException;
         }).isInstanceOf(DomainException.class)
@@ -25,7 +25,7 @@ class DomainExceptionCodeTest {
 
     @Test
     void 파라미터가_존재하는_에러도_정상적으로_생성됩니다() {
-        var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+        var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
         assertThatThrownBy(() -> {
             throw domainException;
         }).isInstanceOf(DomainException.class)

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/controller/PostControllerTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/controller/PostControllerTest.java
@@ -88,7 +88,7 @@ class PostControllerTest {
                     .content("content")
                     .build();
 
-            var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.generateError();
+            var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.create();
             given(postCreateService.execute(request)).willThrow(domainException);
 
             requestNewPostApi(request)
@@ -136,7 +136,7 @@ class PostControllerTest {
                     .title("title")
                     .content("content")
                     .build();
-            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
             given(postEditService.execute(1L, request)).willThrow(domainException);
 
             requestUpdatePostApi(request)
@@ -166,7 +166,7 @@ class PostControllerTest {
 
         @Test
         void 없다면_삭제할_수_없습니다() throws Exception {
-            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
             doThrow(domainException).when(postDeleteService).execute(1L);
 
             mockMvc.perform(delete("/api/posts/{postId}", 1L))
@@ -204,7 +204,7 @@ class PostControllerTest {
         @Test
         void 없다면_조회할_수_없습니다() throws Exception {
 
-            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
             given(postFindService.execute(1L)).willThrow(domainException);
             requestFindPostApi()
                     .andExpect(status().isBadRequest())

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/domain/PostTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/domain/PostTest.java
@@ -41,9 +41,9 @@ class PostTest {
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {101, 102})
+        @ValueSource(ints = {11, 12})
         void 제목이_100글자를_넘기면_오류가_발생한다(int size) {
-            var domainException = DomainExceptionCode.POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(100, size);
+            var domainException = DomainExceptionCode.POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(10, size);
             var input = "-".repeat(size); // 100글자가 넘는 문자열 생성
             assertThatThrownBy(() -> Post.createNewPost(input, "post"))
                     .isInstanceOf(DomainException.class)

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/domain/PostTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/domain/PostTest.java
@@ -27,7 +27,7 @@ class PostTest {
         @ValueSource(strings = {"", "    "})
         void 제목이_없으면_오류가_발생한다(String input) {
             var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.generateError(input);
-            assertThatThrownBy(() -> Post.createNewPost(input, "post"))
+            assertThatThrownBy(() -> Post.create(input, "post"))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
         }
@@ -35,7 +35,7 @@ class PostTest {
         @Test
         void 제목이_null_인_경우_오류가_발생한다() {
             var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.generateError(null);
-            assertThatThrownBy(() -> Post.createNewPost(null, "post"))
+            assertThatThrownBy(() -> Post.create(null, "post"))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
         }
@@ -45,7 +45,7 @@ class PostTest {
         void 제목이_100글자를_넘기면_오류가_발생한다(int size) {
             var domainException = DomainExceptionCode.POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(10, size);
             var input = "-".repeat(size); // 100글자가 넘는 문자열 생성
-            assertThatThrownBy(() -> Post.createNewPost(input, "post"))
+            assertThatThrownBy(() -> Post.create(input, "post"))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
         }
@@ -54,7 +54,7 @@ class PostTest {
         @ValueSource(strings = {"", "    "})
         void 내용이_없으면_오류가_발생한다(String input) {
             var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.generateError(input);
-            assertThatThrownBy(() -> Post.createNewPost("title", input))
+            assertThatThrownBy(() -> Post.create("title", input))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
         }
@@ -62,7 +62,7 @@ class PostTest {
         @Test
         void 내용이_null_인_경우_오류가_발생한다() {
             var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.generateError(null);
-            assertThatThrownBy(() -> Post.createNewPost("title", null))
+            assertThatThrownBy(() -> Post.create("title", null))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
         }
@@ -72,7 +72,7 @@ class PostTest {
         void 내용이_1000자가_넘으면_오류가_발생한다(int size) {
             var input = "-".repeat(size); // 1000글자가 넘는 문자열 생성
             var domainException = DomainExceptionCode.POST_CONTENT_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(1000, size);
-            assertThatThrownBy(() -> Post.createNewPost("title", input))
+            assertThatThrownBy(() -> Post.create("title", input))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
         }
@@ -90,8 +90,8 @@ class PostTest {
             var nextTitle = "next-title";
             var nextContent = "next-content";
 
-            var post = Post.createNewPost(previousTitle, previousContent);
-            var updatePost = post.updatePost(nextTitle, nextContent);
+            var post = Post.create(previousTitle, previousContent);
+            var updatePost = post.update(nextTitle, nextContent);
 
             assertAll(() -> Assertions.assertThat(updatePost.getTitle()).isEqualTo(nextTitle),
                     () -> Assertions.assertThat(updatePost.getContent()).isEqualTo(nextContent)

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/domain/PostTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/domain/PostTest.java
@@ -26,7 +26,7 @@ class PostTest {
         @ParameterizedTest
         @ValueSource(strings = {"", "    "})
         void 제목이_없으면_오류가_발생한다(String input) {
-            var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.generateError(input);
+            var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.create(input);
             assertThatThrownBy(() -> Post.create(input, "post"))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
@@ -34,7 +34,7 @@ class PostTest {
 
         @Test
         void 제목이_null_인_경우_오류가_발생한다() {
-            var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.generateError(null);
+            var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY.create(null);
             assertThatThrownBy(() -> Post.create(null, "post"))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
@@ -43,7 +43,7 @@ class PostTest {
         @ParameterizedTest
         @ValueSource(ints = {11, 12})
         void 제목이_100글자를_넘기면_오류가_발생한다(int size) {
-            var domainException = DomainExceptionCode.POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(10, size);
+            var domainException = DomainExceptionCode.POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.create(10, size);
             var input = "-".repeat(size); // 100글자가 넘는 문자열 생성
             assertThatThrownBy(() -> Post.create(input, "post"))
                     .isInstanceOf(DomainException.class)
@@ -53,7 +53,7 @@ class PostTest {
         @ParameterizedTest
         @ValueSource(strings = {"", "    "})
         void 내용이_없으면_오류가_발생한다(String input) {
-            var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.generateError(input);
+            var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.create(input);
             assertThatThrownBy(() -> Post.create("title", input))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
@@ -61,7 +61,7 @@ class PostTest {
 
         @Test
         void 내용이_null_인_경우_오류가_발생한다() {
-            var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.generateError(null);
+            var domainException = DomainExceptionCode.POST_SHOULD_NOT_CONTENT_EMPTY.create(null);
             assertThatThrownBy(() -> Post.create("title", null))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));
@@ -71,7 +71,7 @@ class PostTest {
         @ValueSource(ints = {1001, 1002})
         void 내용이_1000자가_넘으면_오류가_발생한다(int size) {
             var input = "-".repeat(size); // 1000글자가 넘는 문자열 생성
-            var domainException = DomainExceptionCode.POST_CONTENT_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.generateError(1000, size);
+            var domainException = DomainExceptionCode.POST_CONTENT_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE.create(1000, size);
             assertThatThrownBy(() -> Post.create("title", input))
                     .isInstanceOf(DomainException.class)
                     .satisfies(error -> DomainExceptionValidator.validate(error, domainException));

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
@@ -145,7 +145,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
 
         @Test
         void 아이디가_존재하지_않아서_수정을_실패합니다() throws Exception {
-            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
             var postEditeRequest = PostEditRequest.builder()
                     .build();
             requestPostEditApi(postEditeRequest, 1L)
@@ -187,7 +187,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
 
         @Test
         void 존재하지_않는_게시글은_삭제_실패합니다() throws Exception {
-            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
 
             requestPostDeleteApi(1L)
                     .andExpect(status().isBadRequest())
@@ -230,7 +230,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
 
         @Test
         void 존재하지_않는_게시글은_조회할_수_없습니다() throws Exception {
-            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+            var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
 
             requestPostFindApi(1L)
                     .andExpect(status().isBadRequest())

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
@@ -1,9 +1,17 @@
 package com.jaehong.projectclassjaehongdev.post.integrate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -23,6 +31,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Attributes;
 import org.springframework.test.web.servlet.ResultActions;
 
 
@@ -45,6 +56,24 @@ public class PostApiIntegrateTest extends IntegrateTest {
                     .content(request.getContent())
                     .build();
             requestPostCreateApi(request)
+                    .andDo(document("post-create-success",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestFields(
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목").attributes(
+                                            Attributes.key("constraint").value("제목은 빈칸일 수 없으며 10자 이하만 가능합니다.")
+                                    ),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용").attributes(
+                                            Attributes.key("constraint").value("내용은 빈칸일 수 없으며 1000자 이하만 가능합니다.")
+                                    )
+                            ),
+                            responseFields(
+                                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("아이디"),
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                    fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간")
+                            )
+                    ))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.title").value(response.getTitle()))
                     .andExpect(jsonPath("$.content").value(response.getContent()));
@@ -55,6 +84,14 @@ public class PostApiIntegrateTest extends IntegrateTest {
             var request = PostCreateRequest.builder().build();
             var domainException = DomainExceptionCode.POST_SHOULD_NOT_TITLE_EMPTY;
             requestPostCreateApi(request)
+                    .andDo(document("post-create-fail",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            responseFields(
+                                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("아이디"),
+                                    fieldWithPath("message").type(JsonFieldType.STRING).description("제목")
+                            ))
+                    )
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(domainException.getCode()))
                     .andExpect(jsonPath("$.message").value(domainException.getMessage()));
@@ -82,6 +119,26 @@ public class PostApiIntegrateTest extends IntegrateTest {
                     .content(newContent)
                     .build();
             requestPostEditApi(postEditeRequest, postEntity.getId())
+                    .andDo(document("post-edit",
+                            getDocumentRequest(),
+                            pathParameters(
+                                    parameterWithName("id").description("게시글 id입니다")
+                            ),
+                            requestFields(
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목").attributes(
+                                            Attributes.key("constraint").value("제목은 빈칸일 수 없으며 10자 이하만 가능합니다.")
+                                    ),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용").attributes(
+                                            Attributes.key("constraint").value("내용은 빈칸일 수 없으며 1000자 이하만 가능합니다.")
+                                    )
+                            ),
+                            responseFields(
+                                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("아이디"),
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                    fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간")
+                            )
+                    ))
                     .andExpect(jsonPath("$.title").value(newTitle))
                     .andExpect(jsonPath("$.content").value(newContent));
         }
@@ -117,7 +174,13 @@ public class PostApiIntegrateTest extends IntegrateTest {
             final var postEntity = postRepository.save(Post.createNewPost("title", "content"));
             assertThat(postRepository.findAll().size()).isEqualTo(1);
             requestPostDeleteApi(postEntity.getId())
-                    .andExpect(status().isNoContent());
+                    .andExpect(status().isNoContent())
+                    .andDo(document("post-delete",
+                            getDocumentRequest(),
+                            pathParameters(
+                                    parameterWithName("id").description("게시글 id입니다")
+                            )
+                    ));
 
             assertThat(postRepository.findAll().size()).isEqualTo(0);
         }
@@ -145,6 +208,18 @@ public class PostApiIntegrateTest extends IntegrateTest {
         void 정상적으로_조회됩니다() throws Exception {
             final var postEntity = postRepository.save(Post.createNewPost("title", "content"));
             requestPostFindApi(postEntity.getId())
+                    .andDo(document("post-inquiry",
+                            getDocumentRequest(),
+                            pathParameters(
+                                    parameterWithName("id").description("게시글 id입니다")
+                            ),
+                            responseFields(
+                                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("아이디"),
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                    fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간")
+                            )
+                    ))
                     .andExpect(status().isOk())
                     .andExpectAll(
                             jsonPath("$.id").value(postEntity.getId()),
@@ -164,7 +239,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
         }
 
         private ResultActions requestPostFindApi(Long id) throws Exception {
-            return mockMvc.perform(get("/api/posts/{id}", id))
+            return mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts/{id}", id))
                     .andDo(print());
         }
     }
@@ -179,6 +254,16 @@ public class PostApiIntegrateTest extends IntegrateTest {
                     .collect(Collectors.toList());
             postRepository.saveAll(data);
             requestPostsFindApi()
+                    .andDo(document("post-search-all",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            responseFields(
+                                    beneathPath("posts"),
+                                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("아이디"),
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                    fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간")))
+                    )
                     .andExpect(status().isOk())
                     .andExpectAll(jsonPath("$.posts.length()").value(10));
         }
@@ -190,12 +275,26 @@ public class PostApiIntegrateTest extends IntegrateTest {
                     .collect(Collectors.toList());
             postRepository.saveAll(data);
             requestPostsFindApi("title")
+                    .andDo(document("post-search-keyword",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestParameters(
+                                    parameterWithName("title").description("키워드인 제목입니다.").optional()
+                            ),
+                            responseFields(
+                                    beneathPath("posts"),
+                                    fieldWithPath("id").type(JsonFieldType.NUMBER).description("아이디"),
+                                    fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                    fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                    fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간")
+                            ))
+                    )
                     .andExpect(status().isOk())
                     .andExpectAll(jsonPath("$.posts.length()").value(100));
         }
 
         private ResultActions requestPostsFindApi(String title) throws Exception {
-            return mockMvc.perform(get("/api/posts?title={title}", title))
+            return mockMvc.perform(RestDocumentationRequestBuilders.get("/api/posts?title={title}", title))
                     .andDo(print());
         }
 

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
@@ -111,7 +111,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
 
         @Test
         void 정상적으로_수정이_됩니다() throws Exception {
-            var postEntity = postRepository.save(Post.createNewPost("title", "content"));
+            var postEntity = postRepository.save(Post.create("title", "content"));
             var newTitle = "new title";
             var newContent = "new content";
             var postEditeRequest = PostEditRequest.builder()
@@ -171,7 +171,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
     class PostDeleteAction {
         @Test
         void 정상적으로_삭제합니다() throws Exception {
-            final var postEntity = postRepository.save(Post.createNewPost("title", "content"));
+            final var postEntity = postRepository.save(Post.create("title", "content"));
             assertThat(postRepository.findAll().size()).isEqualTo(1);
             requestPostDeleteApi(postEntity.getId())
                     .andExpect(status().isNoContent())
@@ -206,7 +206,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
     class PostFindAction {
         @Test
         void 정상적으로_조회됩니다() throws Exception {
-            final var postEntity = postRepository.save(Post.createNewPost("title", "content"));
+            final var postEntity = postRepository.save(Post.create("title", "content"));
             requestPostFindApi(postEntity.getId())
                     .andDo(document("post-inquiry",
                             getDocumentRequest(),
@@ -250,7 +250,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
         @Test
         void 정상적으로_조회됩니다() throws Exception {
             var data = LongStream.range(1, 11)
-                    .mapToObj(index -> Post.createNewPost("title" + index, "content" + index))
+                    .mapToObj(index -> Post.create("title" + index, "content" + index))
                     .collect(Collectors.toList());
             postRepository.saveAll(data);
             requestPostsFindApi()
@@ -271,7 +271,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
         @Test
         void _100건이_넘는_결과는_100건만_조회됩니다() throws Exception {
             var data = LongStream.range(1, 111)
-                    .mapToObj(index -> Post.createNewPost("title" + index, "content" + index))
+                    .mapToObj(index -> Post.create("title" + index, "content" + index))
                     .collect(Collectors.toList());
             postRepository.saveAll(data);
             requestPostsFindApi("title")

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/integrate/PostApiIntegrateTest.java
@@ -178,7 +178,7 @@ public class PostApiIntegrateTest extends IntegrateTest {
                     .mapToObj(index -> Post.createNewPost("title" + index, "content" + index))
                     .collect(Collectors.toList());
             postRepository.saveAll(data);
-            requestPostsFindApi("")
+            requestPostsFindApi()
                     .andExpect(status().isOk())
                     .andExpectAll(jsonPath("$.posts.length()").value(10));
         }
@@ -196,6 +196,11 @@ public class PostApiIntegrateTest extends IntegrateTest {
 
         private ResultActions requestPostsFindApi(String title) throws Exception {
             return mockMvc.perform(get("/api/posts?title={title}", title))
+                    .andDo(print());
+        }
+
+        private ResultActions requestPostsFindApi() throws Exception {
+            return mockMvc.perform(get("/api/posts"))
                     .andDo(print());
         }
     }

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryTest.java
@@ -3,7 +3,7 @@ package com.jaehong.projectclassjaehongdev.post.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jaehong.projectclassjaehongdev.post.domain.Post;
-import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.post.vo.PostSearchCondition;
 import com.jaehong.projectclassjaehongdev.utils.annotation.RepositoryTest;
 import java.util.List;
 import java.util.function.IntFunction;
@@ -39,9 +39,9 @@ class PostRepositoryTest {
 
         Assertions.assertAll(
                 () -> assertThat(postRepository.count()).isEqualTo(130),
-                () -> assertThat(postRepository.findBy(PostSearch.builder().title("title").build()).size()).isEqualTo(10),
-                () -> assertThat(postRepository.findBy(PostSearch.builder().title("jaehong").build()).size()).isEqualTo(5),
-                () -> assertThat(postRepository.findBy(PostSearch.builder().title("jscode").build()).size()).isEqualTo(100)
+                () -> assertThat(postRepository.findBy(PostSearchCondition.create("title")).size()).isEqualTo(10),
+                () -> assertThat(postRepository.findBy(PostSearchCondition.create("jaehong")).size()).isEqualTo(5),
+                () -> assertThat(postRepository.findBy(PostSearchCondition.create("jscode")).size()).isEqualTo(100)
         );
     }
 
@@ -49,7 +49,7 @@ class PostRepositoryTest {
     void 게시글_키워드_검색이_빈_값이면_전체_검색() {
         postRepository.saveAllAndFlush(generateSampleData(5, (index) -> Post.createNewPost("title" + index, "content")));
 
-        assertThat(postRepository.findBy(PostSearch.builder().build()).size()).isEqualTo(5);
+        assertThat(postRepository.findBy(PostSearchCondition.createEmptyCondition()).size()).isEqualTo(5);
 
     }
 

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryTest.java
@@ -21,7 +21,7 @@ class PostRepositoryTest {
 
     @Test
     void 게시글이_정상적으로_데이터베이스에_저장됩니다() {
-        var entity = postRepository.save(Post.createNewPost("-".repeat(10), "-".repeat(1000)));
+        var entity = postRepository.save(Post.create("-".repeat(10), "-".repeat(1000)));
 
         assertThat(entity.getTitle()).isEqualTo("-".repeat(10));
         assertThat(entity.getContent()).isEqualTo("-".repeat(1000));
@@ -47,14 +47,14 @@ class PostRepositoryTest {
 
     @Test
     void 게시글_키워드_검색이_빈_값이면_전체_검색() {
-        postRepository.saveAllAndFlush(generateSampleData(5, (index) -> Post.createNewPost("title" + index, "content")));
+        postRepository.saveAllAndFlush(generateSampleData(5, (index) -> Post.create("title" + index, "content")));
 
         assertThat(postRepository.findBy(PostSearchCondition.createEmptyCondition()).size()).isEqualTo(5);
 
     }
 
     private IntFunction<Post> generatePostEntity(String title) {
-        return (index) -> Post.createNewPost(title + index, "content" + index);
+        return (index) -> Post.create(title + index, "content" + index);
     }
 
     private List<Post> generateSampleData(int quantity, IntFunction<Post> createPostEntity) {

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/repository/PostRepositoryTest.java
@@ -21,9 +21,9 @@ class PostRepositoryTest {
 
     @Test
     void 게시글이_정상적으로_데이터베이스에_저장됩니다() {
-        var entity = postRepository.save(Post.createNewPost("-".repeat(100), "-".repeat(1000)));
+        var entity = postRepository.save(Post.createNewPost("-".repeat(10), "-".repeat(1000)));
 
-        assertThat(entity.getTitle()).isEqualTo("-".repeat(100));
+        assertThat(entity.getTitle()).isEqualTo("-".repeat(10));
         assertThat(entity.getContent()).isEqualTo("-".repeat(1000));
     }
 
@@ -33,14 +33,14 @@ class PostRepositoryTest {
         //  title이 포함된 게시글 10개 생성
         postRepository.saveAll(generateSampleData(10, generatePostEntity("title")));
         // jaehongDev가 포함된 게시글 5개 생성
-        postRepository.saveAll(generateSampleData(5, generatePostEntity("jaehongDev")));
+        postRepository.saveAll(generateSampleData(5, generatePostEntity("jaehong")));
         // jscode 가 포함된 게시글 115개 생성
         postRepository.saveAll(generateSampleData(115, generatePostEntity("jscode")));
 
         Assertions.assertAll(
                 () -> assertThat(postRepository.count()).isEqualTo(130),
                 () -> assertThat(postRepository.findBy(PostSearch.builder().title("title").build()).size()).isEqualTo(10),
-                () -> assertThat(postRepository.findBy(PostSearch.builder().title("jaehongDev").build()).size()).isEqualTo(5),
+                () -> assertThat(postRepository.findBy(PostSearch.builder().title("jaehong").build()).size()).isEqualTo(5),
                 () -> assertThat(postRepository.findBy(PostSearch.builder().title("jscode").build()).size()).isEqualTo(100)
         );
     }

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostDeleteServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostDeleteServiceImplTest.java
@@ -29,7 +29,7 @@ class PostDeleteServiceImplTest {
 
     @Test
     void 게시글이_존재하지_않는_경우_에러를_발생시킵니다() {
-        var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+        var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
         given(postRepository.findById(1L)).willReturn(Optional.empty());
         assertThatThrownBy(() -> postDeleteService.execute(1L))
                 .isInstanceOf(DomainException.class)

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostEditServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostEditServiceImplTest.java
@@ -35,7 +35,7 @@ class PostEditServiceImplTest {
                 .title("title")
                 .content("content")
                 .build();
-        var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.generateError(1L);
+        var domainException = DomainExceptionCode.POST_DID_NOT_EXISTS.create(1L);
         given(postRepository.findById(1L)).willReturn(Optional.empty());
         assertThatThrownBy(() -> postEditService.execute(1L, request))
                 .isInstanceOf(DomainException.class)

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.jaehong.projectclassjaehongdev.post.service;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.post.repository.PostRepository;
+import com.jaehong.projectclassjaehongdev.utils.DomainExceptionValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class PostsFindServiceImplTest {
+
+    @InjectMocks
+    private PostsFindServiceImpl postsFindService;
+
+    @Mock
+    private PostRepository postRepository;
+
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 1000})
+    void 게시글을_조회할때_키워드가_공백인_경우_에러를_발생시킨다(int size) {
+
+        String input = " ".repeat(size);
+
+        final var domainException = DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(input);
+        Assertions.assertThatThrownBy(() -> {
+                    postsFindService.execute(PostSearch.builder().title(input).build());
+                }).isInstanceOf(DomainException.class)
+                .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+    }
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImplTest.java
@@ -1,41 +1,60 @@
 package com.jaehong.projectclassjaehongdev.post.service;
 
-import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
-import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import static org.mockito.Mockito.mock;
+
 import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
-import com.jaehong.projectclassjaehongdev.post.repository.PostRepository;
-import com.jaehong.projectclassjaehongdev.utils.DomainExceptionValidator;
-import org.assertj.core.api.Assertions;
+import com.jaehong.projectclassjaehongdev.post.service.strategy.PostFindAllStrategy;
+import com.jaehong.projectclassjaehongdev.post.service.strategy.PostFindKeywordStrategy;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.BDDMockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
 class PostsFindServiceImplTest {
 
-    @InjectMocks
     private PostsFindServiceImpl postsFindService;
+    private PostFindAllStrategy postFindAllStrategy;
+    private PostFindKeywordStrategy postFindKeywordStrategy;
 
-    @Mock
-    private PostRepository postRepository;
 
+    @BeforeEach
+    void setUp() {
+        this.postFindAllStrategy = mock(PostFindAllStrategy.class);
+        this.postFindKeywordStrategy = mock(PostFindKeywordStrategy.class);
+        this.postsFindService = new PostsFindServiceImpl(postFindAllStrategy, postFindKeywordStrategy);
+    }
 
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 1000})
-    void 게시글을_조회할때_키워드가_공백인_경우_에러를_발생시킨다(int size) {
+    void 전략을_실행시키는_서비스에서_게시글을_조회할때_키워드가_공백인_경우_키워드_검색을_실행시킨다(int size) {
 
         String input = " ".repeat(size);
 
-        final var domainException = DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(input);
-        Assertions.assertThatThrownBy(() -> {
-                    postsFindService.execute(PostSearch.builder().title(input).build());
-                }).isInstanceOf(DomainException.class)
-                .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+        var postSearch = PostSearch.builder().title(input).build();
+        postsFindService.execute(postSearch);
+
+        BDDMockito.verify(postFindKeywordStrategy).findBy(postSearch);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"title", "keyword", "jscode"})
+    void 키워드가_공백이_아닌경우_키워드_검색을_실행시킨다(String input) {
+        var postSearch = PostSearch.builder().title(input).build();
+        postsFindService.execute(postSearch);
+        BDDMockito.verify(postFindKeywordStrategy).findBy(postSearch);
+    }
+
+    @Test
+    void 전략을_실행시키는_서비스에서_게시글이_null인경우_전체조회를_실행시킨다() {
+        var postSearch = PostSearch.builder().build();
+        postsFindService.execute(postSearch);
+        BDDMockito.verify(postFindAllStrategy).findBy(postSearch);
     }
 }

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategyTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategyTest.java
@@ -1,0 +1,35 @@
+package com.jaehong.projectclassjaehongdev.post.service.strategy;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
+import com.jaehong.projectclassjaehongdev.utils.DomainExceptionValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class PostFindKeywordStrategyTest {
+    @InjectMocks
+    private PostFindKeywordStrategy postFindKeywordStrategy;
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 1000})
+    void 키워드_검색_전략에서_게시글을_조회할때_키워드가_공백인_경우_에러를_발생시킨다(int size) {
+
+        String input = " ".repeat(size);
+
+        final var domainException = DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(input);
+        Assertions.assertThatThrownBy(() -> {
+                    postFindKeywordStrategy.findBy(PostSearch.builder().title(input).build());
+                }).isInstanceOf(DomainException.class)
+                .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategyTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/service/strategy/PostFindKeywordStrategyTest.java
@@ -25,7 +25,7 @@ class PostFindKeywordStrategyTest {
 
         String input = " ".repeat(size);
 
-        final var domainException = DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.generateError(input);
+        final var domainException = DomainExceptionCode.POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK.create(input);
         Assertions.assertThatThrownBy(() -> {
                     postFindKeywordStrategy.findBy(PostSearch.builder().title(input).build());
                 }).isInstanceOf(DomainException.class)

--- a/src/test/java/com/jaehong/projectclassjaehongdev/utils/test/IntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/utils/test/IntegrateTest.java
@@ -1,26 +1,61 @@
 package com.jaehong.projectclassjaehongdev.utils.test;
 
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jaehong.projectclassjaehongdev.utils.annotation.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
 
 @AutoConfigureMockMvc
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@ExtendWith(SpringExtension.class)
+@ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
 @TestProfile
 @Transactional
+@AutoConfigureRestDocs
 @SpringBootTest
 public class IntegrateTest {
-    @Autowired
     protected MockMvc mockMvc;
     @Autowired
     protected ObjectMapper mapper;
+
+    protected static OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                modifyUris()
+                        .scheme("https")
+                        .host("docs.api.com")
+                        .removePort(),
+                prettyPrint());
+    }
+
+    protected static OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(prettyPrint());
+    }
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
 }

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,10 @@
+|===
+|필드|타입|설명|필수여부|제약조건
+{{#fields}}
+|{{path}}
+|{{type}}
+|{{description}}
+    |{{^optional}}true{{/optional}}
+    |{{#constraint}}{{.}}{{/constraint}}
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
@@ -1,0 +1,5 @@
+|===
+|필드|타입|설명|필수여부
+{{#fields}}|{{path}}|{{type}}|{{description}}|{{^optional}}true{{/optional}}
+{{/fields}}
+|===


### PR DESCRIPTION
안녕하세요! 

이번 미션에서 변경된 요구사항을 해결하기 위해 기존 테스트 코드를 활용하여 리팩토링을 경험 해볼 수 있어 좋았습니다. :) 

[Level5 문서 링크](https://646208019c460d097dd5fca9--dashing-mandazi-0a6f5f.netlify.app/)

아래는 이번 미션을 구현하면서 가졌던 의문점입니다.

1. `@Qualifer` 애노테이션을 사용하면서 생긴 의문점
이전 미션에서 주어진 키워드 검색과 전체 검색을 전략 패턴으로 사용하면 좋을 것 같다고 판단하여 구현해 보았습니다. 

궁금한점)
먼저 서로 다른 전략을  실행시켜주는 구현체에 의존성을 주입하려고 할 때 동일한 인터페이스를 가진 빈에 대한 정보를 알려주기 위해 `@Qualifier` 사용했습니다. **_하지만 해당 방법은 주입되는 빈에 대한 정보를 명시하고 있다고 생각합니다. 그렇기에 `@Qualifier`로 주입해주는 방법과 직접 구현체에 대한 빈을 주입해주는 방법의 차이가 있는지 궁금합니다_**
**ex)**
```java
public PostsFindServiceImpl(
            @Qualifier("PostFindAllStrategy") PostSearchStrategy postFindAllStrategy,
            @Qualifier("PostFindKeywordStrategy") PostSearchStrategy postFindKeywordStrategy) {

        this.postFindAllStrategy = postFindAllStrategy;
        this.postFindKeywordStrategy = postFindKeywordStrategy;
} // ex1

public PostsFindServiceImpl(PostFindAllStrategy postFindAllStrategy, PostFindKeywordStrategy postFindKeywordStrategy) {
        this.postFindAllStrategy = postFindAllStrategy;
        this.postFindKeywordStrategy = postFindKeywordStrategy;
} // ex2 

```
2. Test 코드에서 반복되는 문서화 관련 코드

Level5미션은 문서화입니다. 요구사항에 명시된 Swagger가 아닌 현재 작성한 테스트코드를 바탕으로 문서를 만들면 좋을 것 같다고 생각이들어 `Spring Rest Docs` 를 사용했습니다. 하지만 사용하는 도중 이전 부터 가지고 있던 궁금한 내용이 있어서 질문 남겼습니다.

- 사용하는 도중 반복되는 컬럼의 값 정보를 명시하기 위한 코드가 들어가는데 개선할 방법이 있을까요?
- 통합 테스트에서 문서화를 위한 코드를 작성했지만 기존 테스트코드의 가독성이 떨어진 것 같습니다. 다른 해결 방법이 있을까요?
- 요청에 대한 발생할 수 있는 모든 에러 응답도 문서화로 남기는 것이 좋을까요?