### PR TITLE
[박재홍] 4회차 미션 Level7 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.7.RELEASE'
 

--- a/https/member.http
+++ b/https/member.http
@@ -1,0 +1,25 @@
+### 회원가입
+POST http://localhost:8080/api/auth/signup
+Content-Type: application/json
+
+{
+  "email": "email@email.com",
+  "password": "password"
+}
+
+
+### 로그인
+POST http://localhost:8080/api/auth/signin
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "email@email.com",
+  "password": "password"
+}
+
+
+### 내 정보 조회
+GET http://localhost:8080/api/member/me
+Accept: application/json
+Authorization:bearer eyJhbGciOiJIUzUxMiJ9.eyJpZCI6MSwiaWF0IjoxNjg0Njc0ODc5LCJleHAiOjE2ODQ2Nzg0Nzl9.DTt6ThYzWIKe3jh3RE3ZET_2n5qP3HjtQU90jmteFCu8_0qwMnnZBA69Ut5gzf5t-qsypXn-K5wwO5Qg52fxiw

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -121,7 +121,7 @@ include::{snippets}/post-search-all/http-response.adoc[]
 
 == 응답 필드
 
-include::{snippets}/post-search-all/response-fields.adoc[]
+include::{snippets}/post-search-all/response-fields-beneath-posts.adoc[]
 
 == curl
 
@@ -143,7 +143,7 @@ include::{snippets}/post-search-keyword/http-response.adoc[]
 
 == 응답 필드
 
-include::{snippets}/post-search-keyword/response-fields.adoc[]
+include::{snippets}/post-search-keyword/response-fields-beneath-posts.adoc[]
 
 == curl
 

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/authentication/annotation/MemberId.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/authentication/annotation/MemberId.java
@@ -1,0 +1,12 @@
+package com.jaehong.projectclassjaehongdev.global.authentication.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface MemberId {
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/authentication/annotation/Secured.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/authentication/annotation/Secured.java
@@ -1,0 +1,13 @@
+package com.jaehong.projectclassjaehongdev.global.authentication.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Secured {
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/authentication/exception/AuthenticationException.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/authentication/exception/AuthenticationException.java
@@ -1,0 +1,13 @@
+package com.jaehong.projectclassjaehongdev.global.authentication.exception;
+
+
+import lombok.Getter;
+
+@Getter
+public class AuthenticationException extends RuntimeException {
+    private static final String message = "유효하지 않는 인증입니다.";
+
+    public AuthenticationException() {
+        super(message);
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/config/WebAuthenticationConfiguration.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/config/WebAuthenticationConfiguration.java
@@ -1,0 +1,21 @@
+package com.jaehong.projectclassjaehongdev.global.config;
+
+
+import com.jaehong.projectclassjaehongdev.global.resolver.SignInArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebAuthenticationConfiguration implements WebMvcConfigurer {
+    private final SignInArgumentResolver signInArgumentResolver;
+
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(signInArgumentResolver);
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/config/WebAuthenticationConfiguration.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/config/WebAuthenticationConfiguration.java
@@ -1,7 +1,7 @@
 package com.jaehong.projectclassjaehongdev.global.config;
 
 
-import com.jaehong.projectclassjaehongdev.global.resolver.SignInArgumentResolver;
+import com.jaehong.projectclassjaehongdev.global.resolver.MemberIdArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -11,11 +11,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 @Configuration
 public class WebAuthenticationConfiguration implements WebMvcConfigurer {
-    private final SignInArgumentResolver signInArgumentResolver;
-
+    private final MemberIdArgumentResolver memberIdArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(signInArgumentResolver);
+        resolvers.add(memberIdArgumentResolver);
     }
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/controller/DomainControllerAdvice.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/controller/DomainControllerAdvice.java
@@ -1,9 +1,11 @@
 package com.jaehong.projectclassjaehongdev.global.controller;
 
+import com.jaehong.projectclassjaehongdev.global.authentication.exception.AuthenticationException;
 import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -30,6 +32,16 @@ public class DomainControllerAdvice {
                 .body(ErrorResponse.builder()
                         .code(1)
                         .message("서버에서 알 수 없는 에러가 발생했습니다.")
+                        .build());
+
+    }
+
+    @ExceptionHandler({AuthenticationException.class})
+    public ResponseEntity<ErrorResponse> throwAuthenticationException(AuthenticationException exception) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.builder()
+                        .code(2)
+                        .message(exception.getMessage())
                         .build());
 
     }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/controller/DomainControllerAdvice.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/controller/DomainControllerAdvice.java
@@ -3,10 +3,12 @@ package com.jaehong.projectclassjaehongdev.global.controller;
 import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class DomainControllerAdvice {
 
@@ -22,6 +24,8 @@ public class DomainControllerAdvice {
 
     @ExceptionHandler({RuntimeException.class})
     public ResponseEntity<ErrorResponse> throwRuntimeException(RuntimeException exception) {
+
+        log.error("{}", exception);
         return ResponseEntity.internalServerError()
                 .body(ErrorResponse.builder()
                         .code(1)

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
@@ -22,6 +22,7 @@ public enum DomainExceptionCode {
     MEMBER_SHOULD_NOT_PASSWORD_EMPTY(MEMBER.code + 3, "회원의 패스워드는 필수적으로 필요합니다."),
     MEMBER_PASSWORD_INVALID_SIZE(MEMBER.code + 4, "회원의 비밀번호의 길이는 %d이상 %d이하 입니다. (size: %d)"),
     MEMBER_EXISTS_EMAIL(MEMBER.code + 5, "이미 존재하는 이메일 입니다. (input: %s)"),
+    MEMBER_ID_DID_NOT_EXISTS(MEMBER.code + 6, "존재하지 않는 회원 아이디 입니다 (input:%d)"),
     AUTH(3000, ""),
     AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION(AUTH.code + 1, "부정확한 아이디 비밀번호 입니다.");
 

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
@@ -21,7 +21,9 @@ public enum DomainExceptionCode {
     MEMBER_EMAIL_INVALID(MEMBER.code + 2, "회원의 이메일이 유효하지 않습니다. (input: %s)"),
     MEMBER_SHOULD_NOT_PASSWORD_EMPTY(MEMBER.code + 3, "회원의 패스워드는 필수적으로 필요합니다."),
     MEMBER_PASSWORD_INVALID_SIZE(MEMBER.code + 4, "회원의 비밀번호의 길이는 %d이상 %d이하 입니다. (size: %d)"),
-    MEMBER_EXISTS_EMAIL(MEMBER.code + 5, "이미 존재하는 이메일 입니다. (input: %s)");
+    MEMBER_EXISTS_EMAIL(MEMBER.code + 5, "이미 존재하는 이메일 입니다. (input: %s)"),
+    AUTH(3000, ""),
+    AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION(AUTH.code + 1, "부정확한 아이디 비밀번호 입니다.");
 
     private static final String BASIC_ERROR_FORMAT = "[ERROR] [CODE:%d] [Message: %s]";
     private final Integer code;

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/domain/DomainExceptionCode.java
@@ -14,7 +14,14 @@ public enum DomainExceptionCode {
     POST_TITLE_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE(POST.code + 3, "게시글 제목은 %d보다 길게 작성할 수 없습니다 (size: %d)"),
     POST_CONTENT_SIZE_SHOULD_NOT_OVER_THAN_MAX_VALUE(POST.code + 4, "게시글 내용은 %d보다 길게 작성할 수 없습니다 (size: %d)"),
     POST_DID_NOT_EXISTS(POST.code + 5, "존재하지 않는 게시글 id 입니다 [id: %d]"),
-    POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK(POST.code + 6, "게시글 키워드는 공백을 제외한 1글자 이상이여야 한다 (input: %s)");
+    POST_SEARCH_KEYWORD_SHOULD_NOT_BE_BLANK(POST.code + 6, "게시글 키워드는 공백을 제외한 1글자 이상이여야 한다 (input: %s)"),
+
+    MEMBER(2000, ""),
+    MEMBER_SHOULD_NOT_EMAIL_EMPTY(MEMBER.code + 1, "회원의 이메일은 필수적으로 필요합니다."),
+    MEMBER_EMAIL_INVALID(MEMBER.code + 2, "회원의 이메일이 유효하지 않습니다. (input: %s)"),
+    MEMBER_SHOULD_NOT_PASSWORD_EMPTY(MEMBER.code + 3, "회원의 패스워드는 필수적으로 필요합니다."),
+    MEMBER_PASSWORD_INVALID_SIZE(MEMBER.code + 4, "회원의 비밀번호의 길이는 %d이상 %d이하 입니다. (size: %d)"),
+    MEMBER_EXISTS_EMAIL(MEMBER.code + 5, "이미 존재하는 이메일 입니다. (input: %s)");
 
     private static final String BASIC_ERROR_FORMAT = "[ERROR] [CODE:%d] [Message: %s]";
     private final Integer code;

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolver.java
@@ -43,7 +43,7 @@ public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
 
         final var token = authorizationHeader.substring(AUTHORIZATION_METHOD.length() + 1);
         validateInvalidJwtToken(parameter, token);
-        return this.convertTokenToClaimsId(parameter, token);
+        return this.convertTokenToClaimsId(token);
     }
 
     private void validateInvalidMethodAnnotation(MethodParameter parameter) {
@@ -60,7 +60,7 @@ public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
         }
     }
 
-    private Long convertTokenToClaimsId(MethodParameter parameter, String token) {
+    private Long convertTokenToClaimsId(String token) {
         try {
             return tokenService.getById(token);
         } catch (final Exception e) {

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolver.java
@@ -19,7 +19,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
     private static final String AUTHORIZATION = "Authorization";
     private static final String AUTHORIZATION_METHOD = "Bearer";
     private final TokenService tokenService;

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolver.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolver.java
@@ -2,9 +2,12 @@ package com.jaehong.projectclassjaehongdev.global.resolver;
 
 import com.jaehong.projectclassjaehongdev.global.authentication.annotation.MemberId;
 import com.jaehong.projectclassjaehongdev.global.authentication.annotation.Secured;
+import com.jaehong.projectclassjaehongdev.global.authentication.exception.AuthenticationException;
 import com.jaehong.projectclassjaehongdev.jwt.TokenService;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -12,10 +15,15 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String AUTHORIZATION_METHOD = "Bearer";
     private final TokenService tokenService;
+
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -26,25 +34,46 @@ public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        if (parameter.getMethodAnnotation(Secured.class) == null) {
-            throw new RuntimeException("@Secured 어노테이션을 붙여주세요.");
-        }
+        validateInvalidMethodAnnotation(parameter);
 
         final var request = (HttpServletRequest) webRequest.getNativeRequest();
-        final var authorizationHeader = request.getHeader("Authorization");
+        final var authorizationHeader = request.getHeader(AUTHORIZATION);
 
-        if (authorizationHeader.isBlank() || !authorizationHeader.startsWith("bearer")) {
-            throw new IllegalStateException();
-        }
+        validateTokenAuthorizationHeader(authorizationHeader);
 
-        var token = authorizationHeader.substring(7);
-        if (!tokenService.verifyToken(token)) {
-            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        final var token = authorizationHeader.substring(AUTHORIZATION_METHOD.length() + 1);
+        validateInvalidJwtToken(parameter, token);
+        return this.convertTokenToClaimsId(parameter, token);
+    }
+
+    private void validateInvalidMethodAnnotation(MethodParameter parameter) {
+        if (parameter.getMethodAnnotation(Secured.class) == null) {
+            log.error("@Secured 애노테이션을 붙혀주세요.");
+            throw new AuthenticationException();
         }
+    }
+
+    private void validateTokenAuthorizationHeader(String authorizationHeader) {
+        if (Strings.isBlank(authorizationHeader) || !authorizationHeader.startsWith(AUTHORIZATION_METHOD)) {
+            log.error("유효하지 않는 Authorization header (input:{})", authorizationHeader);
+            throw new AuthenticationException();
+        }
+    }
+
+    private Long convertTokenToClaimsId(MethodParameter parameter, String token) {
         try {
             return tokenService.getById(token);
-        } catch (final NumberFormatException e) {
-            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        } catch (final Exception e) {
+            throw new AuthenticationException();
+        }
+    }
+
+
+    private void validateInvalidJwtToken(MethodParameter parameter, String token) {
+        if (!tokenService.verifyToken(token)) {
+            log.error("유효하지 않는 Authorization 토큰(input:{})", token);
+            log.error("{} - {}", parameter.getClass(), parameter.getMethod());
+            throw new AuthenticationException();
         }
     }
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolver.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolver.java
@@ -1,0 +1,50 @@
+package com.jaehong.projectclassjaehongdev.global.resolver;
+
+import com.jaehong.projectclassjaehongdev.global.authentication.annotation.MemberId;
+import com.jaehong.projectclassjaehongdev.global.authentication.annotation.Secured;
+import com.jaehong.projectclassjaehongdev.jwt.TokenService;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
+    private final TokenService tokenService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class)
+                && parameter.hasParameterAnnotation(MemberId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        if (parameter.getMethodAnnotation(Secured.class) == null) {
+            throw new RuntimeException("@Secured 어노테이션을 붙여주세요.");
+        }
+
+        final var request = (HttpServletRequest) webRequest.getNativeRequest();
+        final var authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader.isBlank() || !authorizationHeader.startsWith("bearer")) {
+            throw new IllegalStateException();
+        }
+
+        var token = authorizationHeader.substring(7);
+        if (!tokenService.verifyToken(token)) {
+            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+        try {
+            return Long.parseLong(tokenService.getSubject(token).toString());
+        } catch (final NumberFormatException e) {
+            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolver.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolver.java
@@ -42,7 +42,7 @@ public class SignInArgumentResolver implements HandlerMethodArgumentResolver {
             throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
         }
         try {
-            return Long.parseLong(tokenService.getSubject(token).toString());
+            return tokenService.getById(token);
         } catch (final NumberFormatException e) {
             throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
         }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
@@ -1,0 +1,5 @@
+package com.jaehong.projectclassjaehongdev.jwt;
+
+public interface TokenService {
+
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
@@ -1,5 +1,11 @@
 package com.jaehong.projectclassjaehongdev.jwt;
 
 public interface TokenService {
+    String issuedToken(Object subject, final long periodSecond);
+
+    String getSubject(final String token);
+
+    boolean verifyToken(final String token);
+
 
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
@@ -3,7 +3,7 @@ package com.jaehong.projectclassjaehongdev.jwt;
 public interface TokenService {
     String issuedToken(Object subject, final long periodSecond);
 
-    String getSubject(final String token);
+    Object getSubject(final String token);
 
     boolean verifyToken(final String token);
 

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenService.java
@@ -1,9 +1,11 @@
 package com.jaehong.projectclassjaehongdev.jwt;
 
 public interface TokenService {
-    String issuedToken(Object subject, final long periodSecond);
+    String issuedToken(Object subject, long periodSecond);
 
-    Object getSubject(final String token);
+
+    Long getById(final String token);
+
 
     boolean verifyToken(final String token);
 

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
@@ -6,12 +6,16 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import org.springframework.stereotype.Service;
 
+@Service
 public class TokenServiceImpl implements TokenService {
     private static final String SECRET_KEY = "SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN";
 
-    public String issuedToken(String subject, final long periodSecond) {
-        final var claims = Jwts.claims().setSubject(subject);
+    @Override
+    public String issuedToken(Object subject, final long periodSecond) {
+        final var claims = Jwts.claims();
+        claims.put("id", subject);
 
         final Date now = new Date();
         return Jwts.builder()
@@ -22,12 +26,14 @@ public class TokenServiceImpl implements TokenService {
                 .compact();
     }
 
+    @Override
     public String getSubject(final String token) {
         final Claims claims = getBody(token);
 
         return claims.getSubject();
     }
 
+    @Override
     public boolean verifyToken(final String token) {
         try {
             final Claims claims = getBody(token);

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
@@ -27,10 +27,10 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
-    public String getSubject(final String token) {
+    public Object getSubject(final String token) {
         final Claims claims = getBody(token);
 
-        return claims.getSubject();
+        return claims.get("id");
     }
 
     @Override

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
@@ -2,6 +2,7 @@ package com.jaehong.projectclassjaehongdev.jwt;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.lang.Maps;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -10,28 +11,27 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class TokenServiceImpl implements TokenService {
+
     private static final String SECRET_KEY = "SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN";
 
     @Override
-    public String issuedToken(Object subject, final long periodSecond) {
-        final var claims = Jwts.claims();
-        claims.put("id", subject);
-
+    public String issuedToken(Object value, long periodSecond) {
+        final var claims = Jwts.claims(Maps.of("id", value).build());
         final Date now = new Date();
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + periodSecond * 1000))
+                .setExpiration(new Date(now.getTime() + periodSecond))
                 .signWith(getSigningKey())
                 .compact();
     }
 
     @Override
-    public Object getSubject(final String token) {
-        final Claims claims = getBody(token);
-
-        return claims.get("id");
+    public Long getById(final String token) {
+        final var claims = getBody(token);
+        return Long.parseLong(claims.get("id").toString());
     }
+
 
     @Override
     public boolean verifyToken(final String token) {

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
@@ -1,0 +1,52 @@
+package com.jaehong.projectclassjaehongdev.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+public class TokenServiceImpl implements TokenService {
+    private static final String SECRET_KEY = "SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN_SECRET_TOKEN";
+
+    public String issuedToken(String subject, final long periodSecond) {
+        final var claims = Jwts.claims().setSubject(subject);
+
+        final Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + periodSecond * 1000))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public String getSubject(final String token) {
+        final Claims claims = getBody(token);
+
+        return claims.getSubject();
+    }
+
+    public boolean verifyToken(final String token) {
+        try {
+            final Claims claims = getBody(token);
+            return claims.getExpiration().after(new Date());
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    private Key getSigningKey() {
+        final byte[] keyBytes = SECRET_KEY.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImpl.java
@@ -17,7 +17,7 @@ public class TokenServiceImpl implements TokenService {
     @Override
     public String issuedToken(Object value, long periodSecond) {
         final var claims = Jwts.claims(Maps.of("id", value).build());
-        final Date now = new Date();
+        final var now = new Date();
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/controller/AuthController.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.jaehong.projectclassjaehongdev.member.controller;
+
+
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+import com.jaehong.projectclassjaehongdev.member.service.SignUpService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final SignUpService signUpService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
+        signUpService.execute(signUpRequest);
+        return ResponseEntity.status(200).build();
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/controller/AuthController.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.jaehong.projectclassjaehongdev.member.controller;
 
 
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignInRequest;
 import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+import com.jaehong.projectclassjaehongdev.member.payload.response.SignInResponse;
+import com.jaehong.projectclassjaehongdev.member.service.SignInService;
 import com.jaehong.projectclassjaehongdev.member.service.SignUpService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +18,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
     private final SignUpService signUpService;
+    private final SignInService signInService;
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
         signUpService.execute(signUpRequest);
         return ResponseEntity.status(200).build();
     }
+
+    @PostMapping("/signin")
+    public ResponseEntity<SignInResponse> sign(@RequestBody SignInRequest signInRequest) {
+        return ResponseEntity.ok(signInService.execute(signInRequest));
+    }
+
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/controller/MemberController.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.jaehong.projectclassjaehongdev.member.controller;
+
+
+import com.jaehong.projectclassjaehongdev.global.authentication.annotation.MemberId;
+import com.jaehong.projectclassjaehongdev.global.authentication.annotation.Secured;
+import com.jaehong.projectclassjaehongdev.member.payload.response.MemberInquiryResponse;
+import com.jaehong.projectclassjaehongdev.member.service.MemberInquiryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/member")
+public class MemberController {
+    private final MemberInquiryService memberInquiryService;
+
+    @Secured
+    @GetMapping("/me")
+    public ResponseEntity<MemberInquiryResponse> getMe(@MemberId Long memberId) {
+        return ResponseEntity.ok(memberInquiryService.execute(memberId));
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Email.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Email.java
@@ -1,0 +1,26 @@
+package com.jaehong.projectclassjaehongdev.member.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Embeddable
+public class Email {
+    @Column(name = "email")
+    private String value;
+
+    private Email(String value) {
+        this.value = StringUtils.trimAllWhitespace(value);
+    }
+
+    public static Email create(String value) {
+        return new Email(value);
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Email.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Email.java
@@ -13,7 +13,7 @@ import org.springframework.util.StringUtils;
 @EqualsAndHashCode
 @Embeddable
 public class Email {
-    @Column(name = "email")
+    @Column(name = "email", unique = true)
     private String value;
 
     private Email(String value) {

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
@@ -38,6 +38,10 @@ public class Member {
         return new Member(email, password);
     }
 
+    public boolean comparePassword(String password) {
+        return this.password.equals(Password.create(password));
+    }
+
     public String getEmail() {
         return this.email.getValue();
     }
@@ -62,4 +66,5 @@ public class Member {
     public int hashCode() {
         return getClass().hashCode();
     }
+
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.Hibernate;
+import org.hibernate.annotations.CreationTimestamp;
 
 
 @Getter
@@ -25,6 +26,7 @@ public class Member {
     private Password password;
     @Embedded
     private Email email;
+    @CreationTimestamp
     private LocalDateTime createdAt;
 
     private Member(String email, String password) {

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
@@ -1,0 +1,65 @@
+package com.jaehong.projectclassjaehongdev.member.domain;
+
+
+import com.jaehong.projectclassjaehongdev.member.domain.policy.MemberValidationPolicy;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
+
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Embedded
+    private Password password;
+    @Embedded
+    private Email email;
+    private LocalDateTime createdAt;
+
+    private Member(String email, String password) {
+        this.email = Email.create(email);
+        this.password = Password.create(password);
+
+        MemberValidationPolicy.validate(this);
+    }
+
+    public static Member create(String email, String password) {
+        return new Member(email, password);
+    }
+
+    public String getEmail() {
+        return this.email.getValue();
+    }
+
+    public String getPassword() {
+        return this.password.getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) {
+            return false;
+        }
+        Member member = (Member) o;
+        return getId() != null && Objects.equals(getId(), member.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Member.java
@@ -9,6 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.Hibernate;
@@ -17,7 +18,7 @@ import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Password.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Password.java
@@ -1,0 +1,26 @@
+package com.jaehong.projectclassjaehongdev.member.domain;
+
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Password {
+    @Column(name = "password")
+    private String value;
+
+    private Password(String value) {
+        this.value = StringUtils.trimAllWhitespace(value);
+    }
+
+    public static Password create(String password) {
+        return new Password(password);
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Password.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/Password.java
@@ -4,6 +4,7 @@ package com.jaehong.projectclassjaehongdev.member.domain;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
@@ -11,6 +12,7 @@ import org.springframework.util.StringUtils;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
 @Embeddable
 public class Password {
     @Column(name = "password")
@@ -23,4 +25,5 @@ public class Password {
     public static Password create(String password) {
         return new Password(password);
     }
+
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/policy/MemberValidationPolicy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/policy/MemberValidationPolicy.java
@@ -1,0 +1,57 @@
+package com.jaehong.projectclassjaehongdev.member.domain.policy;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.member.domain.Member;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public class MemberValidationPolicy {
+
+    private static final int PASSWORD_MIN_LENGTH = 8;
+    private static final int PASSWORD_MAX_LENGTH = 15;
+
+    public static void validate(Member member) {
+
+        validateEmail(member.getEmail());
+        validatePassword(member.getPassword());
+    }
+
+    /**
+     * <p>
+     * - `패스워드`에 공백이 포함될 수 없다. - `패스워드`는 8자 이상 15자 이하여야 한다.
+     * </p>
+     *
+     * @param password
+     */
+    private static void validatePassword(String password) {
+        if (Objects.isNull(password)) {
+            throw DomainExceptionCode.MEMBER_SHOULD_NOT_PASSWORD_EMPTY.create();
+        }
+        if (password.isBlank()) {
+            throw DomainExceptionCode.MEMBER_SHOULD_NOT_PASSWORD_EMPTY.create();
+        }
+        var size = password.length();
+
+        if (size < PASSWORD_MIN_LENGTH || size > PASSWORD_MAX_LENGTH) {
+            throw DomainExceptionCode.MEMBER_PASSWORD_INVALID_SIZE.create(PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH, size);
+        }
+    }
+
+    /**
+     * - `이메일`에 반드시 `@`가 1개만 포함되어 있어야 한다. <br> - `이메일`에 공백이 포함될 수 없다.
+     */
+    private static void validateEmail(String email) {
+        if (Objects.isNull(email)) {
+            throw DomainExceptionCode.MEMBER_SHOULD_NOT_EMAIL_EMPTY.create();
+        }
+
+        if (email.isBlank()) {
+            throw DomainExceptionCode.MEMBER_SHOULD_NOT_EMAIL_EMPTY.create();
+        }
+        // 이메일 유효성 검사
+        var emailPattern = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+        if (!emailPattern.matcher(email).matches()) {
+            throw DomainExceptionCode.MEMBER_EMAIL_INVALID.create(email);
+        }
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/policy/MemberValidationPolicy.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/domain/policy/MemberValidationPolicy.java
@@ -18,7 +18,7 @@ public class MemberValidationPolicy {
 
     /**
      * <p>
-     * - `패스워드`에 공백이 포함될 수 없다. - `패스워드`는 8자 이상 15자 이하여야 한다.
+     * - `패스워드`에 공백이 포함될 수 없다. <br> - `패스워드`는 8자 이상 15자 이하여야 한다.
      * </p>
      *
      * @param password

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/request/SignInRequest.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/request/SignInRequest.java
@@ -1,0 +1,18 @@
+package com.jaehong.projectclassjaehongdev.member.payload.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignInRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/request/SignUpRequest.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/request/SignUpRequest.java
@@ -1,0 +1,19 @@
+package com.jaehong.projectclassjaehongdev.member.payload.request;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignUpRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/response/MemberInquiryResponse.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/response/MemberInquiryResponse.java
@@ -1,0 +1,16 @@
+package com.jaehong.projectclassjaehongdev.member.payload.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@RequiredArgsConstructor
+@Builder
+@Getter
+public class MemberInquiryResponse {
+    private final Long id;
+    private final String email;
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/response/SignInResponse.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/payload/response/SignInResponse.java
@@ -1,0 +1,15 @@
+package com.jaehong.projectclassjaehongdev.member.payload.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignInResponse {
+    private final String token;
+
+    public static SignInResponse from(String token) {
+        return new SignInResponse(token);
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/repository/MemberRepository.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.jaehong.projectclassjaehongdev.member.repository;
+
+import com.jaehong.projectclassjaehongdev.member.domain.Email;
+import com.jaehong.projectclassjaehongdev.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(Email email);
+
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/MemberInquiryService.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/MemberInquiryService.java
@@ -1,0 +1,7 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import com.jaehong.projectclassjaehongdev.member.payload.response.MemberInquiryResponse;
+
+public interface MemberInquiryService {
+    MemberInquiryResponse execute(Long id);
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/MemberInquiryServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/MemberInquiryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.member.payload.response.MemberInquiryResponse;
+import com.jaehong.projectclassjaehongdev.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class MemberInquiryServiceImpl implements MemberInquiryService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberInquiryResponse execute(Long id) {
+        var member = memberRepository.findById(id).orElseThrow(() -> DomainExceptionCode.MEMBER_ID_DID_NOT_EXISTS.create(id));
+
+        return MemberInquiryResponse.builder()
+                .email(member.getEmail())
+                .id(member.getId())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInInServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInInServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class SignInInServiceImpl implements SignInService {
+    private static final int periodSecond = 60 * 60 * 1000; // 1시간
     private final MemberRepository memberRepository;
     private final TokenService tokenService;
 
@@ -25,6 +26,6 @@ public class SignInInServiceImpl implements SignInService {
         if (!member.comparePassword(request.getPassword())) {
             throw DomainExceptionCode.AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION.create();
         }
-        return SignInResponse.from(tokenService.issuedToken(member.getId(), 3600));
+        return SignInResponse.from(tokenService.issuedToken(member.getId(), periodSecond));
     }
 }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInInServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInInServiceImpl.java
@@ -1,0 +1,30 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.jwt.TokenService;
+import com.jaehong.projectclassjaehongdev.member.domain.Email;
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignInRequest;
+import com.jaehong.projectclassjaehongdev.member.payload.response.SignInResponse;
+import com.jaehong.projectclassjaehongdev.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SignInInServiceImpl implements SignInService {
+    private final MemberRepository memberRepository;
+    private final TokenService tokenService;
+
+
+    @Override
+    public SignInResponse execute(SignInRequest request) {
+        var member = memberRepository.findByEmail(Email.create(request.getEmail()))
+                .orElseThrow(DomainExceptionCode.AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION::create);
+
+        if (!member.comparePassword(request.getPassword())) {
+            throw DomainExceptionCode.AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION.create();
+        }
+        return SignInResponse.from(tokenService.issuedToken(member.getId(), 3600));
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInService.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInService.java
@@ -1,0 +1,9 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignInRequest;
+import com.jaehong.projectclassjaehongdev.member.payload.response.SignInResponse;
+
+public interface SignInService {
+
+    SignInResponse execute(SignInRequest request);
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignInServiceImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class SignInInServiceImpl implements SignInService {
+public class SignInServiceImpl implements SignInService {
     private static final int periodSecond = 60 * 60 * 1000; // 1시간
     private final MemberRepository memberRepository;
     private final TokenService tokenService;

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignUpService.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignUpService.java
@@ -1,0 +1,8 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+
+public interface SignUpService {
+    void execute(SignUpRequest request);
+
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignUpServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/member/service/SignUpServiceImpl.java
@@ -1,0 +1,28 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.member.domain.Email;
+import com.jaehong.projectclassjaehongdev.member.domain.Member;
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+import com.jaehong.projectclassjaehongdev.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpServiceImpl implements SignUpService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Override
+    public void execute(SignUpRequest request) {
+        memberRepository.findByEmail(Email.create(request.getEmail()))
+                .ifPresent((member) -> {
+                    throw DomainExceptionCode.MEMBER_EXISTS_EMAIL.create(member.getEmail());
+                });
+
+        var member = Member.create(request.getEmail(), request.getPassword());
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
@@ -17,7 +17,6 @@ public class PostsFindServiceImpl implements PostsFindService {
     public PostsFindServiceImpl(
             @Qualifier("PostFindAllStrategy") PostSearchStrategy postFindAllStrategy,
             @Qualifier("PostFindKeywordStrategy") PostSearchStrategy postFindKeywordStrategy) {
-
         this.postFindAllStrategy = postFindAllStrategy;
         this.postFindKeywordStrategy = postFindKeywordStrategy;
     }

--- a/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
+++ b/src/main/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImpl.java
@@ -2,24 +2,19 @@ package com.jaehong.projectclassjaehongdev.post.service;
 
 import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
 import com.jaehong.projectclassjaehongdev.post.payload.response.PostsResponse;
-import com.jaehong.projectclassjaehongdev.post.service.strategy.PostSearchStrategy;
+import com.jaehong.projectclassjaehongdev.post.service.strategy.PostFindAllStrategy;
+import com.jaehong.projectclassjaehongdev.post.service.strategy.PostFindKeywordStrategy;
 import java.util.Objects;
-import org.springframework.beans.factory.annotation.Qualifier;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
+@RequiredArgsConstructor
 @Service
 public class PostsFindServiceImpl implements PostsFindService {
-    private final PostSearchStrategy postFindAllStrategy;
-    private final PostSearchStrategy postFindKeywordStrategy;
-
-    public PostsFindServiceImpl(
-            @Qualifier("PostFindAllStrategy") PostSearchStrategy postFindAllStrategy,
-            @Qualifier("PostFindKeywordStrategy") PostSearchStrategy postFindKeywordStrategy) {
-        this.postFindAllStrategy = postFindAllStrategy;
-        this.postFindKeywordStrategy = postFindKeywordStrategy;
-    }
+    private final PostFindAllStrategy postFindAllStrategy;
+    private final PostFindKeywordStrategy postFindKeywordStrategy;
 
     @Transactional(readOnly = true)
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     database: mysql
     hibernate:
-      ddlAuto:create
+      ddlAuto: create
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolverIntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolverIntegrateTest.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @DisplayName("인증 Resolver가 정상적으로 컨트롤러에서 처리되는지 테스트")
 @WebMvcTest({SampleController.class, TokenService.class})
-public class SignInArgumentResolverIntegrateTest {
+public class MemberIdArgumentResolverIntegrateTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolverTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/MemberIdArgumentResolverTest.java
@@ -27,9 +27,9 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ArgumentResolver의 토큰 검증 단위테스트")
-class SignInArgumentResolverTest {
+class MemberIdArgumentResolverTest {
     @InjectMocks
-    private SignInArgumentResolver signInArgumentResolver;
+    private MemberIdArgumentResolver memberIdArgumentResolver;
     @Mock
     private TokenService tokenService;
     @Mock
@@ -46,7 +46,7 @@ class SignInArgumentResolverTest {
     @Test
     void Secured_애노테이션이_존재하지_않는_경우_에러가_발생한다() {
         given(methodParameter.getMethodAnnotation(Secured.class)).willReturn(null);
-        assertThatThrownBy(() -> signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
+        assertThatThrownBy(() -> memberIdArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
                 .isInstanceOf(AuthenticationException.class);
     }
 
@@ -57,7 +57,7 @@ class SignInArgumentResolverTest {
         given(webRequest.getNativeRequest()).willReturn(httpRequest);
         given(httpRequest.getHeader("Authorization")).willReturn(null);
 
-        assertThatThrownBy(() -> signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
+        assertThatThrownBy(() -> memberIdArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
                 .isInstanceOf(AuthenticationException.class);
     }
 
@@ -69,7 +69,7 @@ class SignInArgumentResolverTest {
         given(httpRequest.getHeader("Authorization")).willReturn(token);
         given(tokenService.verifyToken(any())).willReturn(false);
 
-        assertThatThrownBy(() -> signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
+        assertThatThrownBy(() -> memberIdArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
                 .isInstanceOf(AuthenticationException.class);
     }
 
@@ -82,7 +82,7 @@ class SignInArgumentResolverTest {
         given(tokenService.verifyToken(any())).willReturn(true);
         given(tokenService.getById(any())).willReturn(1L);
 
-        var result = signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory);
+        var result = memberIdArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory);
         Assertions.assertThat(result).isEqualTo(1L);
     }
 

--- a/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolverIntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolverIntegrateTest.java
@@ -1,0 +1,89 @@
+package com.jaehong.projectclassjaehongdev.global.resolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jaehong.projectclassjaehongdev.global.authentication.annotation.MemberId;
+import com.jaehong.projectclassjaehongdev.global.authentication.annotation.Secured;
+import com.jaehong.projectclassjaehongdev.jwt.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("인증 Resolver가 정상적으로 컨트롤러에서 처리되는지 테스트")
+@WebMvcTest({SampleController.class, TokenService.class})
+public class SignInArgumentResolverIntegrateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Test
+    void 애노테이션이_존재하지_않는_인증_컨트롤러에_요청하면_에러응답을_받습니다() throws Exception {
+        mockMvc.perform(get("/test"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 애노테이션이_존재하지만_헤더가_없는_경우_에러가_발생한다() throws Exception {
+        mockMvc.perform(get("/test2"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 헤더의_형태가_잘못된경우() throws Exception {
+        mockMvc.perform(get("/test2").header("Authorization", "XXX"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 유효하지_않는_토큰의_경우_에러_응답이_발생한다() throws Exception {
+        //만료된 토큰 생성
+        var token = tokenService.issuedToken(1L, -1);
+        mockMvc.perform(get("/test2").header("Authorization", "Bearer " + token))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 정상적인_토큰의_경우_SUCCESS_응답이_발생한다() throws Exception {
+        var token = tokenService.issuedToken(1L, 3600 * 10000);
+        mockMvc.perform(get("/test2").header("Authorization", "Bearer " + token))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("SUCCESS"));
+    }
+
+
+}
+
+@RestController
+class SampleController {
+
+    @GetMapping("/test")
+    public ResponseEntity<String> getInformation(@MemberId Long id) {
+        return ResponseEntity.ok("SUCCESS");
+    }
+
+    @Secured
+    @GetMapping("/test2")
+    public ResponseEntity<String> getInformation2(@MemberId Long id) {
+        return ResponseEntity.ok("SUCCESS");
+    }
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolverTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/global/resolver/SignInArgumentResolverTest.java
@@ -1,0 +1,89 @@
+package com.jaehong.projectclassjaehongdev.global.resolver;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.jaehong.projectclassjaehongdev.global.authentication.annotation.Secured;
+import com.jaehong.projectclassjaehongdev.global.authentication.exception.AuthenticationException;
+import com.jaehong.projectclassjaehongdev.jwt.TokenService;
+import javax.servlet.http.HttpServletRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ArgumentResolver의 토큰 검증 단위테스트")
+class SignInArgumentResolverTest {
+    @InjectMocks
+    private SignInArgumentResolver signInArgumentResolver;
+    @Mock
+    private TokenService tokenService;
+    @Mock
+    private MethodParameter methodParameter;
+    @Mock
+    private ModelAndViewContainer modelAndViewContainer;
+    @Mock
+    private NativeWebRequest webRequest;
+    @Mock
+    private WebDataBinderFactory binderFactory;
+    @Mock
+    private HttpServletRequest httpRequest;
+
+    @Test
+    void Secured_애노테이션이_존재하지_않는_경우_에러가_발생한다() {
+        given(methodParameter.getMethodAnnotation(Secured.class)).willReturn(null);
+        assertThatThrownBy(() -> signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
+                .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void Authorization_헤더가_존재하지_않는경우_에러가_발생한다() {
+
+        given(methodParameter.getMethodAnnotation(Secured.class)).willReturn(mock(Secured.class));
+        given(webRequest.getNativeRequest()).willReturn(httpRequest);
+        given(httpRequest.getHeader("Authorization")).willReturn(null);
+
+        assertThatThrownBy(() -> signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
+                .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void 유효하지_않는_토큰의_경우_에러가_발생한다() {
+        var token = "Bearer token";
+        given(methodParameter.getMethodAnnotation(Secured.class)).willReturn(mock(Secured.class));
+        given(webRequest.getNativeRequest()).willReturn(httpRequest);
+        given(httpRequest.getHeader("Authorization")).willReturn(token);
+        given(tokenService.verifyToken(any())).willReturn(false);
+
+        assertThatThrownBy(() -> signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory))
+                .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void 정상적인_토큰의_경우_사용자_아이디를_반환한다() {
+        var token = "Bearer token";
+        given(methodParameter.getMethodAnnotation(Secured.class)).willReturn(mock(Secured.class));
+        given(webRequest.getNativeRequest()).willReturn(httpRequest);
+        given(httpRequest.getHeader("Authorization")).willReturn(token);
+        given(tokenService.verifyToken(any())).willReturn(true);
+        given(tokenService.getById(any())).willReturn(1L);
+
+        var result = signInArgumentResolver.resolveArgument(methodParameter, modelAndViewContainer, webRequest, binderFactory);
+        Assertions.assertThat(result).isEqualTo(1L);
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImplTest.java
@@ -1,0 +1,20 @@
+package com.jaehong.projectclassjaehongdev.jwt;
+
+import org.junit.jupiter.api.Test;
+
+class TokenServiceImplTest {
+
+    @Test
+    void 토큰_테스트() {
+        var tokenService = new TokenServiceImpl();
+
+        var token = tokenService.issuedToken("1", 1);
+
+        System.out.println(token);
+
+        var id = tokenService.getSubject(token);
+        System.out.println(tokenService.verifyToken(token));
+        System.out.println(id);
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/jwt/TokenServiceImplTest.java
@@ -1,20 +1,23 @@
 package com.jaehong.projectclassjaehongdev.jwt;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TokenServiceImplTest {
 
     @Test
-    void 토큰_테스트() {
+    void 토큰이_정상적으로_디코딩_된다() {
         var tokenService = new TokenServiceImpl();
+        var token = tokenService.issuedToken(1L, 60 * 60 * 10000);
+        var id = tokenService.getById(token);
+        Assertions.assertThat(id).isEqualTo(1);
+    }
 
-        var token = tokenService.issuedToken("1", 1);
-
-        System.out.println(token);
-
-        var id = tokenService.getSubject(token);
-        System.out.println(tokenService.verifyToken(token));
-        System.out.println(id);
+    @Test
+    void 기간이_만료된_토큰의_경우_토큰을_사용할_수_없는_토큰으로_표시된다() {
+        var tokenService = new TokenServiceImpl();
+        var token = tokenService.issuedToken(1L, -1); // 현재 시간보다 -1초 늦게 만듦
+        Assertions.assertThat(tokenService.verifyToken(token)).isFalse();
     }
 
 }

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.jaehong.projectclassjaehongdev.member.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -9,29 +10,33 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.jwt.TokenService;
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignInRequest;
 import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+import com.jaehong.projectclassjaehongdev.member.payload.response.SignInResponse;
+import com.jaehong.projectclassjaehongdev.member.service.SignInService;
 import com.jaehong.projectclassjaehongdev.member.service.SignUpService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @DisplayName("컨트롤러 단위 테스트")
-@WebMvcTest(AuthController.class)
-@ExtendWith(MockitoExtension.class)
+@WebMvcTest({AuthController.class, TokenService.class})
 class AuthControllerTest {
 
     @MockBean
     private SignUpService signUpService;
+    @MockBean
+    private SignInService signInService;
     @Autowired
     private ObjectMapper mapper;
     @Autowired
@@ -41,7 +46,6 @@ class AuthControllerTest {
     @Nested
     @DisplayName("회원가입에서")
     class SignUpTest {
-
         @Test
         void 중복되는_이메일이_입력되면_에러를_응답한다() throws Exception {
             var request = SignUpRequest.builder()
@@ -60,7 +64,45 @@ class AuthControllerTest {
                             jsonPath("$.message").value(domainException.getMessage())
                     );
         }
+    }
 
+    @Nested
+    @DisplayName("로그인에서")
+    class SignInTest {
+        SignInRequest request = SignInRequest.builder()
+                .email("email@email.com")
+                .password("password")
+                .build();
+
+        @Test
+        void 로그인할_수_없는_요청이_발생한_경우_에러_응답이_발생한다() throws Exception {
+            var domainException = DomainExceptionCode.AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION.create();
+
+            given(signInService.execute(request)).willThrow(domainException);
+
+            requestSigInApi(request)
+                    .andExpectAll(status().isBadRequest(),
+                            jsonPath("$.code").value(domainException.getCode()),
+                            jsonPath("$.message").value(domainException.getMessage())
+                    );
+        }
+
+        @Test
+        void 로그인에_성공한_경우() throws Exception {
+            var response = SignInResponse.from("token");
+            given(signInService.execute(request)).willReturn(response);
+            requestSigInApi(request)
+                    .andExpectAll(status().isOk(), jsonPath("$.token").value(response.getToken()));
+
+        }
+
+        private ResultActions requestSigInApi(SignInRequest request) throws Exception {
+            return mockMvc.perform(post("/api/auth/signin")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsBytes(request)))
+                    .andDo(print());
+
+        }
     }
 
 }

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/controller/AuthControllerTest.java
@@ -1,0 +1,66 @@
+package com.jaehong.projectclassjaehongdev.member.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+import com.jaehong.projectclassjaehongdev.member.service.SignUpService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DisplayName("컨트롤러 단위 테스트")
+@WebMvcTest(AuthController.class)
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @MockBean
+    private SignUpService signUpService;
+    @Autowired
+    private ObjectMapper mapper;
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    @Nested
+    @DisplayName("회원가입에서")
+    class SignUpTest {
+
+        @Test
+        void 중복되는_이메일이_입력되면_에러를_응답한다() throws Exception {
+            var request = SignUpRequest.builder()
+                    .email("email@email.com")
+                    .password("password")
+                    .build();
+            var domainException = DomainExceptionCode.MEMBER_EXISTS_EMAIL.create(request.getEmail());
+
+            doThrow(domainException).when(signUpService).execute(any());
+
+            mockMvc.perform(post("/api/auth/signup").content(mapper.writeValueAsBytes(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpectAll(status().isBadRequest(),
+                            jsonPath("$.code").value(domainException.getCode()),
+                            jsonPath("$.message").value(domainException.getMessage())
+                    );
+        }
+
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/controller/MemberControllerTest.java
@@ -1,0 +1,58 @@
+package com.jaehong.projectclassjaehongdev.member.controller;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jaehong.projectclassjaehongdev.global.resolver.MemberIdArgumentResolver;
+import com.jaehong.projectclassjaehongdev.jwt.TokenService;
+import com.jaehong.projectclassjaehongdev.member.payload.response.MemberInquiryResponse;
+import com.jaehong.projectclassjaehongdev.member.service.MemberInquiryService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@WebMvcTest({MemberController.class, TokenService.class})
+@DisplayName("회원 컨트롤러 단위 테스트")
+class MemberControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberIdArgumentResolver memberIdArgumentResolver;
+
+    @MockBean
+    private MemberInquiryService memberInquiryService;
+
+    @Test
+    void 개인정보를_조회할_수_있습니다() throws Exception {
+        given(memberIdArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+        var response = MemberInquiryResponse.builder()
+                .email("email@email.com")
+                .id(1L)
+                .createdAt(LocalDateTime.now()).build();
+        given(memberInquiryService.execute(any())).willReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/member/me"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpectAll(status().isOk(),
+                        jsonPath("$.id").value(response.getId()),
+                        jsonPath("$.email").value(response.getEmail()));
+
+    }
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/domain/MemberTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/domain/MemberTest.java
@@ -1,0 +1,84 @@
+package com.jaehong.projectclassjaehongdev.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.utils.DomainExceptionValidator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class 회원_도메인을 {
+    @Nested
+    class 생성할_때 {
+        @Test
+        void 이메일이_null인_경우_생성할_수_없습니다() {
+            var domainException = DomainExceptionCode.MEMBER_SHOULD_NOT_EMAIL_EMPTY.create();
+            assertThatThrownBy(() -> Member.create(null, "password"))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 3, 10, 1000})
+        void 이메일이_비어있는_경우_생성할_수_없습니다(int size) {
+            var input = " ".repeat(size);
+            var domainException = DomainExceptionCode.MEMBER_SHOULD_NOT_EMAIL_EMPTY.create();
+            assertThatThrownBy(() -> Member.create(input, "password"))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"1234", "email@", "  @"})
+        void 이메일이_올바르지_않는_경우_에러가_발생합니다(String input) {
+            var domainException = DomainExceptionCode.MEMBER_EMAIL_INVALID.create(Email.create(input).getValue());
+            assertThatThrownBy(() -> Member.create(input, "password"))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"email@email.com ", "e m a i l @ e m a i l . com"})
+        void 이메일에_공백이_들어가더라도_제거된_상태로_생성됩니다(final String input) {
+            var member = Member.create(input, "password");
+            Assertions.assertThat(member.getEmail()).isEqualTo("email@email.com");
+        }
+
+        @Test
+        void 패스워드에_공백혹은_null이_들어가면_생성할_수_없습니다() {
+            var domainException = DomainExceptionCode.MEMBER_SHOULD_NOT_PASSWORD_EMPTY.create();
+            assertAll(() -> assertThatThrownBy(() -> Member.create("email@email.com", null))
+                            .satisfies((error) -> DomainExceptionValidator.validate(error, domainException)),
+                    () -> assertThatThrownBy(() -> Member.create("email@email.com", ""))
+                            .satisfies((error) -> DomainExceptionValidator.validate(error, domainException)));
+        }
+
+        @ParameterizedTest()
+        @ValueSource(ints = {6, 7, 16, 17})
+        void 이메일이_8자_이상_15자_이하가_아닌경우_오류가_발생합니다(int size) {
+            var domainException = DomainExceptionCode.MEMBER_PASSWORD_INVALID_SIZE.create(8, 15, size);
+            var password = "-".repeat(size);
+            assertThatThrownBy(() -> Member.create("email@email.com", password))
+                    .isInstanceOf(DomainException.class)
+                    .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"password ", "p a s s w o r d"})
+        void 패스워드에_공백이_들어가더라도_제거된_상태로_생성됩니다(final String input) {
+            var member = Member.create("email@email.com", input);
+            Assertions.assertThat(member.getPassword()).isEqualTo("password");
+        }
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/domain/MemberTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/domain/MemberTest.java
@@ -81,4 +81,18 @@ class 회원_도메인을 {
         }
     }
 
+    @Nested
+    class 로그인을_확인할때 {
+        @Test
+        void 동일한_비밀번호면_참을_반환한다() {
+            var member = Member.create("email@email.com", "password");
+            Assertions.assertThat(member.comparePassword("password")).isTrue();
+        }
+
+        @Test
+        void 다른_비밀번호를_사용하면_거짓을_반환한다() {
+            var member = Member.create("email@email.com", "password");
+            Assertions.assertThat(member.comparePassword("otherpassword")).isFalse();
+        }
+    }
 }

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/integrate/MemberApiIntegrateTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/integrate/MemberApiIntegrateTest.java
@@ -1,0 +1,79 @@
+package com.jaehong.projectclassjaehongdev.member.integrate;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.member.domain.Email;
+import com.jaehong.projectclassjaehongdev.member.domain.Member;
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+import com.jaehong.projectclassjaehongdev.member.repository.MemberRepository;
+import com.jaehong.projectclassjaehongdev.utils.test.IntegrateTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+@DisplayName("통합 테스트")
+public class MemberApiIntegrateTest extends IntegrateTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("사용자의 회원가입에서")
+    class SignUp {
+
+        SignUpRequest signUpRequest;
+
+        @BeforeEach
+        void setUp() {
+            this.signUpRequest = SignUpRequest.builder()
+                    .email("email@email.com")
+                    .password("password")
+                    .build();
+        }
+
+        @Test
+        void 중복되는_이메일을_생성하는_경우_오류가_발생한다() throws Exception {
+
+            var domainException = DomainExceptionCode.MEMBER_EXISTS_EMAIL.create(signUpRequest.getEmail());
+            memberRepository.save(Member.create(signUpRequest.getEmail(), signUpRequest.getPassword()));
+
+            signUpRequestApi(signUpRequest)
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            jsonPath("$.code").value(domainException.getCode()),
+                            jsonPath("$.message").value(domainException.getMessage())
+                    );
+        }
+
+        @Test
+        void 성공적으로_완료된다() throws Exception {
+            signUpRequestApi(signUpRequest)
+                    .andExpect(status().isOk());
+            var member = memberRepository.findByEmail(Email.create(signUpRequest.getEmail())).orElseThrow();
+
+            assertAll(() -> assertThat(member.getEmail()).isEqualTo(signUpRequest.getEmail()),
+                    () -> assertThat(member.getPassword()).isEqualTo(signUpRequest.getPassword()));
+
+
+        }
+
+        private ResultActions signUpRequestApi(SignUpRequest request) throws Exception {
+            return mockMvc.perform(post("/api/auth/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsBytes(request)))
+                    .andDo(print());
+        }
+
+    }
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.jaehong.projectclassjaehongdev.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.jaehong.projectclassjaehongdev.member.domain.Member;
+import com.jaehong.projectclassjaehongdev.utils.annotation.RepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+
+@RepositoryTest
+class MemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 회원이_정상적으로_데이터베이스에_저장됩니다() {
+
+        var email = "email@email.com";
+        var password = "password";
+        var member = memberRepository.save(Member.create(email, password));
+
+        assertAll(() -> assertThat(member.getEmail()).isEqualTo(email),
+                () -> assertThat(member.getPassword()).isEqualTo(password));
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/service/MemberInquiryServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/service/MemberInquiryServiceImplTest.java
@@ -1,0 +1,40 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.member.repository.MemberRepository;
+import com.jaehong.projectclassjaehongdev.utils.DomainExceptionValidator;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class MemberInquiryServiceImplTest {
+
+    @InjectMocks
+    private MemberInquiryServiceImpl memberInquiryService;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Test
+    void 존재하지_않는_회원_아이디의_경우_에러가_발생한다() {
+        given(memberRepository.findById(any())).willReturn(Optional.empty());
+
+        var domainException = DomainExceptionCode.MEMBER_ID_DID_NOT_EXISTS.create(1L);
+        assertThatThrownBy(() -> memberInquiryService.execute(1L)).isInstanceOf(DomainException.class)
+                .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/service/SignInServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/service/SignInServiceImplTest.java
@@ -29,7 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SignInServiceImplTest {
     @InjectMocks
-    private SignInInServiceImpl signInInService;
+    private SignInServiceImpl signInInService;
     @Mock
     private MemberRepository memberRepository;
     @Mock

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/service/SignInServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/service/SignInServiceImplTest.java
@@ -1,0 +1,83 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.jwt.TokenServiceImpl;
+import com.jaehong.projectclassjaehongdev.member.domain.Member;
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignInRequest;
+import com.jaehong.projectclassjaehongdev.member.payload.response.SignInResponse;
+import com.jaehong.projectclassjaehongdev.member.repository.MemberRepository;
+import com.jaehong.projectclassjaehongdev.utils.DomainExceptionValidator;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class SignInServiceImplTest {
+    @InjectMocks
+    private SignInInServiceImpl signInInService;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private TokenServiceImpl tokenService;
+
+    /**
+     *
+     */
+    @Test
+    void 존재하지_않는_사용자_정보로_로그인하는_경우_에러가_발생합니다() {
+        var domainException = DomainExceptionCode.AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION.create();
+        var request = SignInRequest.builder()
+                .email("email@email.com")
+                .password("password")
+                .build();
+        given(memberRepository.findByEmail(any())).willReturn(Optional.empty());
+        assertThatThrownBy(() -> signInInService.execute(request))
+                .isInstanceOf(DomainException.class)
+                .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+    }
+
+    @Test
+    void 패스워드가_부정확하면_에러가_발생합니다() {
+        var domainException = DomainExceptionCode.AUTH_DID_NOT_CORRECT_LOGIN_INFORMATION.create();
+        var request = SignInRequest.builder()
+                .email("email@email.com")
+                .password("password")
+                .build();
+        var member = Member.create("email@email.com", "otherpassword");
+        given(memberRepository.findByEmail(any())).willReturn(Optional.of(member));
+        assertThatThrownBy(() -> signInInService.execute(request))
+                .isInstanceOf(DomainException.class)
+                .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+    }
+
+    @Test
+    void 로그인이_성공적으로_진행되면_토큰이_발급됩니다() {
+        var request = SignInRequest.builder()
+                .email("email@email.com")
+                .password("password")
+                .build();
+        var response = SignInResponse.from("token");
+        var member = Member.create("email@email.com", "password");
+        given(memberRepository.findByEmail(any())).willReturn(Optional.of(member));
+        when(tokenService.issuedToken(any(), anyLong())).thenReturn(response.getToken());
+
+        signInInService.execute(request);
+        assertThat(response.getToken()).isEqualTo("token");
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/member/service/SignUpServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/member/service/SignUpServiceImplTest.java
@@ -1,0 +1,51 @@
+package com.jaehong.projectclassjaehongdev.member.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.jaehong.projectclassjaehongdev.global.domain.DomainException;
+import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.member.domain.Email;
+import com.jaehong.projectclassjaehongdev.member.domain.Member;
+import com.jaehong.projectclassjaehongdev.member.payload.request.SignUpRequest;
+import com.jaehong.projectclassjaehongdev.member.repository.MemberRepository;
+import com.jaehong.projectclassjaehongdev.utils.DomainExceptionValidator;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class SignUpServiceImplTest {
+
+    @InjectMocks
+    private SignUpServiceImpl signUpService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    //보류
+    @Test
+    void 중복되는_이메일이_생성되는_경우_에러가_발생합니다() {
+        var email = "duplicate@email.com";
+        var domainException = DomainExceptionCode.MEMBER_EXISTS_EMAIL.create(email);
+        var request = SignUpRequest.builder().email(email)
+                .password("password")
+                .build();
+
+        given(memberRepository.findByEmail(Email.create(email)))
+                .willReturn(Optional.of(Member.create(email, request.getPassword())));
+
+        assertThatThrownBy(() -> signUpService.execute(request))
+                .isInstanceOf(DomainException.class)
+                .satisfies((error) -> DomainExceptionValidator.validate(error, domainException));
+
+    }
+
+}

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/controller/PostControllerTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/controller/PostControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jaehong.projectclassjaehongdev.global.domain.DomainExceptionCode;
+import com.jaehong.projectclassjaehongdev.jwt.TokenService;
 import com.jaehong.projectclassjaehongdev.post.payload.request.PostCreateRequest;
 import com.jaehong.projectclassjaehongdev.post.payload.request.PostEditRequest;
 import com.jaehong.projectclassjaehongdev.post.payload.request.PostSearch;
@@ -42,7 +43,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @DisplayName("post controller 단위 테스트")
-@WebMvcTest(PostController.class)
+@WebMvcTest({PostController.class, TokenService.class})
 class PostControllerTest {
     @MockBean
     PostEditService postEditService;

--- a/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImplTest.java
+++ b/src/test/java/com/jaehong/projectclassjaehongdev/post/service/PostsFindServiceImplTest.java
@@ -23,7 +23,6 @@ class PostsFindServiceImplTest {
     private PostFindAllStrategy postFindAllStrategy;
     private PostFindKeywordStrategy postFindKeywordStrategy;
 
-
     @BeforeEach
     void setUp() {
         this.postFindAllStrategy = mock(PostFindAllStrategy.class);


### PR DESCRIPTION

### 질문
> 먼저 서로 다른 전략을 실행시켜주는 구현체에 의존성을 주입하려고 할 때 동일한 인터페이스를 가진 빈에 대한 정보를 알려주기 위해 @qualifier 사용했습니다. 하지만 해당 방법은 주입되는 빈에 대한 정보를 명시하고 있다고 생각합니다. 그렇기에 @qualifier로 주입해주는 방법과 직접 구현체에 대한 빈을 주입해주는 방법의 차이가 있는지 궁금합니다

### 답변
> 이렇게 사용하는건 둘 차이가 별로 없지 않을까 싶습니다😅 내부 동작 방식은 다를 수 있겠지만.. 추상화되지 않고 각각 명시해서 주입해준다는게 같으니까요. 결과적으로 매번 같은 빈이 주입되기도 하고요. 그렇기 때문에 굳이 @qualifier로 가져와야 하나 싶습니다~
### 피드백 반영
![image](https://github.com/JSCODE-EDU/project-class-JaehongDev/assets/73726591/7bde7358-71e3-470c-9606-175781599363)


### 🤔 커밋의 기능 단위의 기준

최근 `기능 단위`라는 것에 대해 제가 알고 있는 내용이 맞는지 궁금해졌습니다. 

만약 회원가입 기능을 구현하고 커밋을 하려고 다음과 같이 볼 수 있을 것 같습니다.

- 컨트롤러 계층부터 도메인 계층까지 모든 계층을 아울러 하나의 기능으로 본다.

혹은 

- 컨트롤러 계층에서 회원가입 api
- 서비스 계층에서 회원가입 기능
- 도메인에서 회원가입에 필요한 데이터 생성 기능

이렇게 기능이라는 것도 계층별로 나눠서 각 계층의 기능 형태로 커밋을 할 수 있다는 생각이 들었습니다.

### 🤔 빈으로 등록되는 컴포넌트의 명명 규칙에는 ?

흔히 컨트롤러, 서비스, 리포지터리, 엔티티 (*controller, *service, *repository, *entity) 와 같은 특정한 고유 키워드를 붙히는 방식으로 계층을 나누거나 서로의 역할을 분리할 수 있습니다. 

그러다 보면 위 영역에 속하지 않는 설정, 인프라, 혹은 특정 기능을 수행하는 기능의 집합체에 대한 명명 규칙이 궁금합니다!

### 패키지를 분리하는 방법에 대한 의문점

최근 gradle의 모듈 프로그래밍 같은 자바 패키지를 모듈 단위로 분리하는 코드를 종종 보게 되었습니다. 

그런 코드들은 대부분 도메인 단위로 분리되는 것이 아닌 계층 단위로 분리되는 것을 볼 수 있는데 리뷰어님이 주로 사용하시는 방법이 궁금합니다!

### 🤔 ArgumentResolver를 테스트하는 방법

이번에 JWT 토큰이 담긴 Header를 처리할 때 ArgumentResolver를 통해서 처리한 이후 payload에 담긴 id값을 컨트롤러의 파라미터에 전달하는 방법을 사용했습니다.

이렇게 처리하고 난 이후 컨트롤러가 인증을 처리하는 책임을 분리했기 때문에 상당히 편리하게 사용할 수 있었습니다.

하지만 편리하게 사용할 수 있는 것과는 별개로 테스트하기는 상당히 어려웠다고 생각합니다.
![image](https://github.com/JSCODE-EDU/project-class-JaehongDev/assets/73726591/ba8466c9-8178-4df9-8370-5f12a905e28b)
토큰의 헤더에 존재하는 값을 검증하기 위해서 해당 메서드에서 인자로 받는 4개의 파라미터를 전부 mocking 하는 상황이 발생했고 

그러다보니 정상적으로 동작하는지 단위테스트를 하는 코드에서도 다음과 같은 작업을 해줘야 하는 만큼 번거로움이 있었습니다.
![image](https://github.com/JSCODE-EDU/project-class-JaehongDev/assets/73726591/9a117c68-5649-4863-88cb-433c2fddc279)
파라미터가 4개까지 있는 상황은 흔하지 않지만 그런데도 이런 상황이 발생했을 때 이런 번거로움을 줄여서 단위테스트를 할 방법이 있을까요?
